### PR TITLE
Tune linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,15 @@ linters-settings:
     go: 1.16
   stylecheck:
     go: 1.16
+  govet:
+    check-shadowing: true
+    enable-all: true
+  cyclop:
+    max-complexity: 24
+  gci:
+    local-prefixes: github.com/limpidchart
+  goimports:
+    local-prefixes: github.com/limpidchart
 linters:
   enable:
     - deadcode

--- a/internal/validation/chart_margins_test.go
+++ b/internal/validation/chart_margins_test.go
@@ -3,14 +3,16 @@ package validation_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
 	"github.com/limpidchart/lc-api/internal/validation"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateChartMargins(t *testing.T) {
 	t.Parallel()
 
+	//nolint: govet
 	tt := []struct {
 		name         string
 		chartMargins *render.ChartMargins

--- a/internal/validation/chart_sizes_test.go
+++ b/internal/validation/chart_sizes_test.go
@@ -3,14 +3,16 @@ package validation_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
 	"github.com/limpidchart/lc-api/internal/validation"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateChartSizes(t *testing.T) {
 	t.Parallel()
 
+	//nolint: govet
 	tt := []struct {
 		name        string
 		chartSizes  *render.ChartSizes


### PR DESCRIPTION
Add new settings for `govet`, `cyclop`, `gci`, `goimports`.