### PR TITLE
Add common testing chart structs

### DIFF
--- a/internal/testutils/chartrequests.go
+++ b/internal/testutils/chartrequests.go
@@ -1,22 +1,15 @@
-package convert_test
+package testutils
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	"github.com/limpidchart/lc-api/internal/convert"
 	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
-	"github.com/limpidchart/lc-api/internal/testutils"
 )
 
-func TestCreateChartRequestToRenderChartRequest(t *testing.T) {
-	t.Parallel()
-
-	expected := &render.RenderChartRequest{
-		RequestId: "",
-		Title:     "Vertical and line chart",
+func VerticalBarAndLineCreateChartRequest() *render.CreateChartRequest {
+	//nolint: gomnd
+	return &render.CreateChartRequest{
+		Title: "Vertical and line chart",
 		Sizes: &render.ChartSizes{
 			Width:  &wrapperspb.Int32Value{Value: 100},
 			Height: &wrapperspb.Int32Value{Value: 200},
@@ -30,20 +23,16 @@ func TestCreateChartRequestToRenderChartRequest(t *testing.T) {
 		Axes: &render.ChartAxes{
 			AxisTop:         nil,
 			AxisTopLabel:    "",
-			AxisBottom:      testutils.BandChartScale(),
+			AxisBottom:      BandChartScale(),
 			AxisBottomLabel: "Categories",
-			AxisLeft:        testutils.LinearChartScaleWithDefaults(),
+			AxisLeft:        LinearChartScale(),
 			AxisLeftLabel:   "Values",
 			AxisRight:       nil,
 			AxisRightLabel:  "",
 		},
 		Views: []*render.ChartView{
-			testutils.VerticalBarViewWithDefaults(),
-			testutils.LineViewWithDefaults(),
+			VerticalBarView(),
+			LineView(),
 		},
 	}
-
-	actual, err := convert.CreateChartRequestToRenderChartRequest(testutils.VerticalBarAndLineCreateChartRequest())
-	assert.NoError(t, err)
-	assert.Equal(t, expected, actual)
 }

--- a/internal/testutils/chartscales.go
+++ b/internal/testutils/chartscales.go
@@ -1,0 +1,89 @@
+package testutils
+
+import (
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+)
+
+func BandChartScale() *render.ChartScale {
+	//nolint: gomnd
+	return &render.ChartScale{
+		Kind:       render.ChartScale_BAND,
+		RangeStart: &wrapperspb.Int32Value{Value: 0},
+		RangeEnd:   &wrapperspb.Int32Value{Value: 100},
+		Domain: &render.ChartScale_DomainCategories{
+			DomainCategories: &render.DomainCategories{Categories: []string{"A", "B", "C"}},
+		},
+		NoBoundariesOffset: false,
+		InnerPadding:       &wrapperspb.FloatValue{Value: 0.2},
+		OuterPadding:       &wrapperspb.FloatValue{Value: 0.2},
+	}
+}
+
+func BandChartScaleWithoutKind() *render.ChartScale {
+	res := BandChartScale()
+	res.Kind = render.ChartScale_UNSPECIFIED_SCALE
+
+	return res
+}
+
+func BandChartScaleWithoutCategoriesDomain() *render.ChartScale {
+	res := BandChartScale()
+
+	//nolint: gomnd
+	res.Domain = &render.ChartScale_DomainNumeric{
+		DomainNumeric: &render.DomainNumeric{
+			Start: 20,
+			End:   40,
+		},
+	}
+
+	return res
+}
+
+func BandChartScaleWithoutDomain() *render.ChartScale {
+	res := BandChartScale()
+	res.Domain = nil
+
+	return res
+}
+
+func LinearChartScale() *render.ChartScale {
+	//nolint: gomnd
+	return &render.ChartScale{
+		Kind:       render.ChartScale_LINEAR,
+		RangeStart: &wrapperspb.Int32Value{Value: 0},
+		RangeEnd:   &wrapperspb.Int32Value{Value: 100},
+		Domain: &render.ChartScale_DomainNumeric{
+			DomainNumeric: &render.DomainNumeric{
+				Start: 0,
+				End:   100,
+			},
+		},
+		NoBoundariesOffset: false,
+		InnerPadding:       nil,
+		OuterPadding:       nil,
+	}
+}
+
+func LinearChartScaleWithDefaults() *render.ChartScale {
+	res := LinearChartScale()
+
+	//nolint: gomnd
+	res.InnerPadding = &wrapperspb.FloatValue{Value: 0.1}
+
+	//nolint: gomnd
+	res.OuterPadding = &wrapperspb.FloatValue{Value: 0.1}
+
+	return res
+}
+
+func LinearChartScaleWithoutNumericDomain() *render.ChartScale {
+	res := LinearChartScale()
+	res.Domain = &render.ChartScale_DomainCategories{
+		DomainCategories: &render.DomainCategories{Categories: []string{"a1", "a2"}},
+	}
+
+	return res
+}

--- a/internal/testutils/chartviews.go
+++ b/internal/testutils/chartviews.go
@@ -1,0 +1,263 @@
+package testutils
+
+import (
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+)
+
+func ColorsDefault() *render.ChartViewColors {
+	return &render.ChartViewColors{
+		FillColor: &render.ChartElementColor{
+			ColorValue: &render.ChartElementColor_ColorHex{
+				ColorHex: "#71c7ec",
+			},
+		},
+		StrokeColor: &render.ChartElementColor{
+			ColorValue: &render.ChartElementColor_ColorHex{
+				ColorHex: "#005073",
+			},
+		},
+		PointFillColor: &render.ChartElementColor{
+			ColorValue: &render.ChartElementColor_ColorHex{
+				ColorHex: "#71c7ec",
+			},
+		},
+		PointStrokeColor: &render.ChartElementColor{
+			ColorValue: &render.ChartElementColor_ColorHex{
+				ColorHex: "#005073",
+			},
+		},
+	}
+}
+
+func HorizontalBarView() *render.ChartView {
+	return &render.ChartView{
+		Kind: render.ChartView_HORIZONTAL_BAR,
+		Values: &render.ChartView_BarsValues{
+			BarsValues: &render.ChartViewBarsValues{
+				BarsDatasets: []*render.ChartViewBarsValues_BarsDataset{
+					{
+						Values: []float32{10, 20},
+						FillColor: &render.ChartElementColor{
+							ColorValue: &render.ChartElementColor_ColorHex{
+								ColorHex: "#66b2b2",
+							},
+						},
+						StrokeColor: &render.ChartElementColor{
+							ColorValue: &render.ChartElementColor_ColorHex{
+								ColorHex: "#004c4c",
+							},
+						},
+					},
+				},
+			},
+		},
+		Colors:             nil,
+		BarLabelVisible:    &wrapperspb.BoolValue{Value: false},
+		BarLabelPosition:   render.ChartView_END_OUTSIDE,
+		PointVisible:       nil,
+		PointType:          0,
+		PointLabelVisible:  nil,
+		PointLabelPosition: 0,
+	}
+}
+
+func HorizontalBarViewWithDefaults() *render.ChartView {
+	res := HorizontalBarView()
+	res.Colors = ColorsDefault()
+	res.PointVisible = &wrapperspb.BoolValue{Value: true}
+	res.PointType = render.ChartView_CIRCLE
+	res.PointLabelVisible = &wrapperspb.BoolValue{Value: true}
+	res.PointLabelPosition = render.ChartView_TOP
+
+	return res
+}
+
+func AreaView() *render.ChartView {
+	return &render.ChartView{
+		Kind: render.ChartView_AREA,
+		Values: &render.ChartView_ScalarValues{
+			ScalarValues: &render.ChartViewScalarValues{
+				Values: []float32{1010, 2100},
+			},
+		},
+		Colors: &render.ChartViewColors{
+			FillColor: &render.ChartElementColor{
+				ColorValue: &render.ChartElementColor_ColorHex{
+					ColorHex: "#71c7ee",
+				},
+			},
+			StrokeColor: &render.ChartElementColor{
+				ColorValue: &render.ChartElementColor_ColorHex{
+					ColorHex: "#005072",
+				},
+			},
+			PointFillColor:   nil,
+			PointStrokeColor: nil,
+		},
+		BarLabelVisible:    nil,
+		BarLabelPosition:   0,
+		PointVisible:       &wrapperspb.BoolValue{Value: false},
+		PointType:          render.ChartView_X,
+		PointLabelVisible:  &wrapperspb.BoolValue{Value: false},
+		PointLabelPosition: render.ChartView_TOP,
+	}
+}
+
+func AreaViewWithDefaults() *render.ChartView {
+	res := AreaView()
+	res.Colors = ColorsDefault()
+	res.Colors.FillColor = &render.ChartElementColor{
+		ColorValue: &render.ChartElementColor_ColorHex{
+			ColorHex: "#71c7ee",
+		},
+	}
+	res.Colors.StrokeColor = &render.ChartElementColor{
+		ColorValue: &render.ChartElementColor_ColorHex{
+			ColorHex: "#005072",
+		},
+	}
+	res.BarLabelVisible = &wrapperspb.BoolValue{Value: true}
+	res.BarLabelPosition = render.ChartView_CENTER
+
+	return res
+}
+
+func AreaViewBadRGBColor() *render.ChartView {
+	res := AreaView()
+	res.Colors = ColorsDefault()
+
+	//nolint: gomnd
+	res.Colors.FillColor = &render.ChartElementColor{
+		ColorValue: &render.ChartElementColor_ColorRgb{
+			ColorRgb: &render.ChartElementColor_RGB{
+				R: 1,
+				G: 320,
+				B: 2,
+			},
+		},
+	}
+
+	return res
+}
+
+func ScatterView() *render.ChartView {
+	//nolint: gomnd
+	return &render.ChartView{
+		Kind: render.ChartView_SCATTER,
+		Values: &render.ChartView_PointsValues{
+			PointsValues: &render.ChartViewPointsValues{
+				Points: []*render.ChartViewPointsValues_Point{
+					{
+						X: 321,
+						Y: 8741,
+					},
+					{
+						X: 23,
+						Y: 85,
+					},
+				},
+			},
+		},
+		Colors:             nil,
+		BarLabelVisible:    nil,
+		BarLabelPosition:   0,
+		PointVisible:       &wrapperspb.BoolValue{Value: true},
+		PointType:          render.ChartView_CIRCLE,
+		PointLabelVisible:  &wrapperspb.BoolValue{Value: true},
+		PointLabelPosition: render.ChartView_TOP_LEFT,
+	}
+}
+
+func ScatterViewWithDefaults() *render.ChartView {
+	res := ScatterView()
+	res.Colors = ColorsDefault()
+	res.BarLabelVisible = &wrapperspb.BoolValue{Value: true}
+	res.BarLabelPosition = render.ChartView_CENTER
+
+	return res
+}
+
+func LineView() *render.ChartView {
+	return &render.ChartView{
+		Kind: render.ChartView_LINE,
+		Values: &render.ChartView_ScalarValues{
+			ScalarValues: &render.ChartViewScalarValues{
+				Values: []float32{40, 50, 60},
+			},
+		},
+		Colors:             ColorsDefault(),
+		BarLabelVisible:    nil,
+		BarLabelPosition:   0,
+		PointVisible:       &wrapperspb.BoolValue{Value: true},
+		PointType:          render.ChartView_X,
+		PointLabelVisible:  &wrapperspb.BoolValue{Value: true},
+		PointLabelPosition: render.ChartView_LEFT,
+	}
+}
+
+func LineViewWithDefaults() *render.ChartView {
+	res := LineView()
+	res.BarLabelVisible = &wrapperspb.BoolValue{Value: true}
+	res.BarLabelPosition = render.ChartView_CENTER
+
+	return res
+}
+
+func VerticalBarView() *render.ChartView {
+	return &render.ChartView{
+		Kind: render.ChartView_VERTICAL_BAR,
+		Values: &render.ChartView_BarsValues{
+			BarsValues: &render.ChartViewBarsValues{
+				BarsDatasets: []*render.ChartViewBarsValues_BarsDataset{
+					{
+						Values: []float32{11, 22, 33},
+						FillColor: &render.ChartElementColor{
+							ColorValue: &render.ChartElementColor_ColorHex{
+								ColorHex: "#fff4e6",
+							},
+						},
+						StrokeColor: &render.ChartElementColor{
+							ColorValue: &render.ChartElementColor_ColorHex{
+								ColorHex: "#3c2f2f",
+							},
+						},
+					},
+				},
+			},
+		},
+		Colors:             nil,
+		BarLabelVisible:    &wrapperspb.BoolValue{Value: true},
+		BarLabelPosition:   render.ChartView_END_INSIDE,
+		PointVisible:       nil,
+		PointType:          0,
+		PointLabelVisible:  nil,
+		PointLabelPosition: 0,
+	}
+}
+
+func VerticalBarViewWithDefaults() *render.ChartView {
+	res := VerticalBarView()
+	res.Colors = ColorsDefault()
+	res.PointVisible = &wrapperspb.BoolValue{Value: true}
+	res.PointType = render.ChartView_CIRCLE
+	res.PointLabelVisible = &wrapperspb.BoolValue{Value: true}
+	res.PointLabelPosition = render.ChartView_TOP
+
+	return res
+}
+
+func UnspecifiedKindView() *render.ChartView {
+	res := HorizontalBarView()
+	res.Kind = render.ChartView_UNSPECIFIED_KIND
+
+	return res
+}
+
+func HorizontalBarViewWithoutValues() *render.ChartView {
+	res := HorizontalBarView()
+	res.Values = nil
+
+	return res
+}

--- a/internal/validate/apitorenderer/chart_axes_test.go
+++ b/internal/validate/apitorenderer/chart_axes_test.go
@@ -4,68 +4,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/testutils"
 	"github.com/limpidchart/lc-api/internal/validate/apitorenderer"
 )
 
-func testingLinearChartScale() *render.ChartScale {
-	return &render.ChartScale{
-		Kind:       render.ChartScale_LINEAR,
-		RangeStart: &wrapperspb.Int32Value{Value: 10},
-		RangeEnd:   &wrapperspb.Int32Value{Value: 100},
-		Domain: &render.ChartScale_DomainNumeric{
-			DomainNumeric: &render.DomainNumeric{
-				Start: 20,
-				End:   40,
-			},
-		},
-		NoBoundariesOffset: false,
-		InnerPadding:       nil,
-		OuterPadding:       nil,
-	}
-}
-
-func testingBandChartScale() *render.ChartScale {
-	return &render.ChartScale{
-		Kind:       render.ChartScale_BAND,
-		RangeStart: &wrapperspb.Int32Value{Value: 0},
-		RangeEnd:   &wrapperspb.Int32Value{Value: 1000},
-		Domain: &render.ChartScale_DomainCategories{
-			DomainCategories: &render.DomainCategories{Categories: []string{"a1", "a2"}},
-		},
-		NoBoundariesOffset: true,
-		InnerPadding:       &wrapperspb.FloatValue{Value: 0.5},
-		OuterPadding:       &wrapperspb.FloatValue{Value: 0.5},
-	}
-}
-
 func TestValidateChartAxes(t *testing.T) {
 	t.Parallel()
-
-	testingLinearChartScaleWithPaddings := testingLinearChartScale()
-	testingLinearChartScaleWithPaddings.InnerPadding = &wrapperspb.FloatValue{Value: 0.1}
-	testingLinearChartScaleWithPaddings.OuterPadding = &wrapperspb.FloatValue{Value: 0.1}
-
-	testingScaleWithoutKind := testingBandChartScale()
-	testingScaleWithoutKind.Kind = render.ChartScale_UNSPECIFIED_SCALE
-
-	testingScaleWithoutDomain := testingBandChartScale()
-	testingScaleWithoutDomain.Domain = nil
-
-	testingScaleWithoutNumericDomain := testingLinearChartScale()
-	testingScaleWithoutNumericDomain.Domain = &render.ChartScale_DomainCategories{
-		DomainCategories: &render.DomainCategories{Categories: []string{"a1", "a2"}},
-	}
-
-	testingScaleWithoutCategoriesDomain := testingBandChartScale()
-	testingScaleWithoutCategoriesDomain.Domain = &render.ChartScale_DomainNumeric{
-		DomainNumeric: &render.DomainNumeric{
-			Start: 20,
-			End:   40,
-		},
-	}
 
 	//nolint: govet
 	tt := []struct {
@@ -77,23 +23,23 @@ func TestValidateChartAxes(t *testing.T) {
 		{
 			"all_is_set",
 			&render.ChartAxes{
-				AxisTop:         testingLinearChartScale(),
+				AxisTop:         testutils.LinearChartScale(),
 				AxisTopLabel:    "top",
-				AxisBottom:      testingLinearChartScale(),
+				AxisBottom:      testutils.LinearChartScale(),
 				AxisBottomLabel: "bottom",
-				AxisLeft:        testingBandChartScale(),
+				AxisLeft:        testutils.BandChartScale(),
 				AxisLeftLabel:   "left",
-				AxisRight:       testingBandChartScale(),
+				AxisRight:       testutils.BandChartScale(),
 				AxisRightLabel:  "right",
 			},
 			&render.ChartAxes{
-				AxisTop:         testingLinearChartScaleWithPaddings,
+				AxisTop:         testutils.LinearChartScaleWithDefaults(),
 				AxisTopLabel:    "top",
-				AxisBottom:      testingLinearChartScaleWithPaddings,
+				AxisBottom:      testutils.LinearChartScaleWithDefaults(),
 				AxisBottomLabel: "bottom",
-				AxisLeft:        testingBandChartScale(),
+				AxisLeft:        testutils.BandChartScale(),
 				AxisLeftLabel:   "left",
-				AxisRight:       testingBandChartScale(),
+				AxisRight:       testutils.BandChartScale(),
 				AxisRightLabel:  "right",
 			},
 			nil,
@@ -103,9 +49,9 @@ func TestValidateChartAxes(t *testing.T) {
 			&render.ChartAxes{
 				AxisTop:         nil,
 				AxisTopLabel:    "",
-				AxisBottom:      testingLinearChartScale(),
+				AxisBottom:      testutils.LinearChartScale(),
 				AxisBottomLabel: "",
-				AxisLeft:        testingBandChartScale(),
+				AxisLeft:        testutils.BandChartScale(),
 				AxisLeftLabel:   "",
 				AxisRight:       nil,
 				AxisRightLabel:  "",
@@ -113,9 +59,9 @@ func TestValidateChartAxes(t *testing.T) {
 			&render.ChartAxes{
 				AxisTop:         nil,
 				AxisTopLabel:    "",
-				AxisBottom:      testingLinearChartScaleWithPaddings,
+				AxisBottom:      testutils.LinearChartScaleWithDefaults(),
 				AxisBottomLabel: "",
-				AxisLeft:        testingBandChartScale(),
+				AxisLeft:        testutils.BandChartScale(),
 				AxisLeftLabel:   "",
 				AxisRight:       nil,
 				AxisRightLabel:  "",
@@ -135,7 +81,7 @@ func TestValidateChartAxes(t *testing.T) {
 				AxisTopLabel:    "",
 				AxisBottom:      nil,
 				AxisBottomLabel: "",
-				AxisLeft:        testingLinearChartScale(),
+				AxisLeft:        testutils.LinearChartScale(),
 				AxisLeftLabel:   "l",
 				AxisRight:       nil,
 				AxisRightLabel:  "",
@@ -146,7 +92,7 @@ func TestValidateChartAxes(t *testing.T) {
 		{
 			"no_left_and_right",
 			&render.ChartAxes{
-				AxisTop:         testingLinearChartScale(),
+				AxisTop:         testutils.LinearChartScale(),
 				AxisTopLabel:    "t",
 				AxisBottom:      nil,
 				AxisBottomLabel: "",
@@ -161,13 +107,13 @@ func TestValidateChartAxes(t *testing.T) {
 		{
 			"no_axis_kind",
 			&render.ChartAxes{
-				AxisTop:         testingLinearChartScale(),
+				AxisTop:         testutils.LinearChartScale(),
 				AxisTopLabel:    "t",
-				AxisBottom:      testingScaleWithoutKind,
+				AxisBottom:      testutils.BandChartScaleWithoutKind(),
 				AxisBottomLabel: "b",
-				AxisLeft:        testingLinearChartScale(),
+				AxisLeft:        testutils.LinearChartScale(),
 				AxisLeftLabel:   "l",
-				AxisRight:       testingLinearChartScale(),
+				AxisRight:       testutils.LinearChartScale(),
 				AxisRightLabel:  "r",
 			},
 			nil,
@@ -176,13 +122,13 @@ func TestValidateChartAxes(t *testing.T) {
 		{
 			"top_and_bottom_diff",
 			&render.ChartAxes{
-				AxisTop:         testingLinearChartScale(),
+				AxisTop:         testutils.LinearChartScale(),
 				AxisTopLabel:    "t",
-				AxisBottom:      testingBandChartScale(),
+				AxisBottom:      testutils.BandChartScale(),
 				AxisBottomLabel: "b",
-				AxisLeft:        testingLinearChartScale(),
+				AxisLeft:        testutils.LinearChartScale(),
 				AxisLeftLabel:   "l",
-				AxisRight:       testingLinearChartScale(),
+				AxisRight:       testutils.LinearChartScale(),
 				AxisRightLabel:  "r",
 			},
 			nil,
@@ -191,13 +137,13 @@ func TestValidateChartAxes(t *testing.T) {
 		{
 			"left_and_right_diff",
 			&render.ChartAxes{
-				AxisTop:         testingLinearChartScale(),
+				AxisTop:         testutils.LinearChartScale(),
 				AxisTopLabel:    "",
-				AxisBottom:      testingLinearChartScale(),
+				AxisBottom:      testutils.LinearChartScale(),
 				AxisBottomLabel: "",
-				AxisLeft:        testingLinearChartScale(),
+				AxisLeft:        testutils.LinearChartScale(),
 				AxisLeftLabel:   "",
-				AxisRight:       testingBandChartScale(),
+				AxisRight:       testutils.BandChartScale(),
 				AxisRightLabel:  "",
 			},
 			nil,
@@ -206,13 +152,13 @@ func TestValidateChartAxes(t *testing.T) {
 		{
 			"no_domain",
 			&render.ChartAxes{
-				AxisTop:         testingLinearChartScale(),
+				AxisTop:         testutils.LinearChartScale(),
 				AxisTopLabel:    "",
-				AxisBottom:      testingLinearChartScale(),
+				AxisBottom:      testutils.LinearChartScale(),
 				AxisBottomLabel: "",
 				AxisLeft:        nil,
 				AxisLeftLabel:   "",
-				AxisRight:       testingScaleWithoutDomain,
+				AxisRight:       testutils.BandChartScaleWithoutDomain(),
 				AxisRightLabel:  "",
 			},
 			nil,
@@ -221,13 +167,13 @@ func TestValidateChartAxes(t *testing.T) {
 		{
 			"no_numeric_domain",
 			&render.ChartAxes{
-				AxisTop:         testingLinearChartScale(),
+				AxisTop:         testutils.LinearChartScale(),
 				AxisTopLabel:    "",
-				AxisBottom:      testingLinearChartScale(),
+				AxisBottom:      testutils.LinearChartScale(),
 				AxisBottomLabel: "",
 				AxisLeft:        nil,
 				AxisLeftLabel:   "",
-				AxisRight:       testingScaleWithoutNumericDomain,
+				AxisRight:       testutils.LinearChartScaleWithoutNumericDomain(),
 				AxisRightLabel:  "",
 			},
 			nil,
@@ -236,13 +182,13 @@ func TestValidateChartAxes(t *testing.T) {
 		{
 			"no_categories_domain",
 			&render.ChartAxes{
-				AxisTop:         testingLinearChartScale(),
+				AxisTop:         testutils.LinearChartScale(),
 				AxisTopLabel:    "",
-				AxisBottom:      testingLinearChartScale(),
+				AxisBottom:      testutils.LinearChartScale(),
 				AxisBottomLabel: "",
 				AxisLeft:        nil,
 				AxisLeftLabel:   "",
-				AxisRight:       testingScaleWithoutCategoriesDomain,
+				AxisRight:       testutils.BandChartScaleWithoutCategoriesDomain(),
 				AxisRightLabel:  "",
 			},
 			nil,

--- a/internal/validate/apitorenderer/chart_view_test.go
+++ b/internal/validate/apitorenderer/chart_view_test.go
@@ -4,265 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/testutils"
 	"github.com/limpidchart/lc-api/internal/validate/apitorenderer"
 )
-
-func testingColorsDefault() *render.ChartViewColors {
-	return &render.ChartViewColors{
-		FillColor: &render.ChartElementColor{
-			ColorValue: &render.ChartElementColor_ColorHex{
-				ColorHex: "#71c7ec",
-			},
-		},
-		StrokeColor: &render.ChartElementColor{
-			ColorValue: &render.ChartElementColor_ColorHex{
-				ColorHex: "#005073",
-			},
-		},
-		PointFillColor: &render.ChartElementColor{
-			ColorValue: &render.ChartElementColor_ColorHex{
-				ColorHex: "#71c7ec",
-			},
-		},
-		PointStrokeColor: &render.ChartElementColor{
-			ColorValue: &render.ChartElementColor_ColorHex{
-				ColorHex: "#005073",
-			},
-		},
-	}
-}
-
-func testingChartUnspecifiedKind() *render.ChartView {
-	res := testingHorizontalBarView()
-	res.Kind = render.ChartView_UNSPECIFIED_KIND
-
-	return res
-}
-
-func testingChartNoValues() *render.ChartView {
-	res := testingHorizontalBarView()
-	res.Values = nil
-
-	return res
-}
-
-func testingHorizontalBarView() *render.ChartView {
-	return &render.ChartView{
-		Kind: render.ChartView_HORIZONTAL_BAR,
-		Values: &render.ChartView_BarsValues{
-			BarsValues: &render.ChartViewBarsValues{
-				BarsDatasets: []*render.ChartViewBarsValues_BarsDataset{
-					{
-						Values: []float32{10, 20},
-						FillColor: &render.ChartElementColor{
-							ColorValue: &render.ChartElementColor_ColorHex{
-								ColorHex: "#66b2b2",
-							},
-						},
-						StrokeColor: &render.ChartElementColor{
-							ColorValue: &render.ChartElementColor_ColorHex{
-								ColorHex: "#004c4c",
-							},
-						},
-					},
-				},
-			},
-		},
-		Colors:             nil,
-		BarLabelVisible:    &wrapperspb.BoolValue{Value: false},
-		BarLabelPosition:   render.ChartView_END_OUTSIDE,
-		PointVisible:       nil,
-		PointType:          0,
-		PointLabelVisible:  nil,
-		PointLabelPosition: 0,
-	}
-}
-
-func testingHorizontalBarViewWithDefaults() *render.ChartView {
-	res := testingHorizontalBarView()
-	res.Colors = testingColorsDefault()
-	res.PointVisible = &wrapperspb.BoolValue{Value: true}
-	res.PointType = render.ChartView_CIRCLE
-	res.PointLabelVisible = &wrapperspb.BoolValue{Value: true}
-	res.PointLabelPosition = render.ChartView_TOP
-
-	return res
-}
-
-func testingAreaView() *render.ChartView {
-	return &render.ChartView{
-		Kind: render.ChartView_AREA,
-		Values: &render.ChartView_ScalarValues{
-			ScalarValues: &render.ChartViewScalarValues{
-				Values: []float32{1010, 2100},
-			},
-		},
-		Colors: &render.ChartViewColors{
-			FillColor: &render.ChartElementColor{
-				ColorValue: &render.ChartElementColor_ColorHex{
-					ColorHex: "#71c7ee",
-				},
-			},
-			StrokeColor: &render.ChartElementColor{
-				ColorValue: &render.ChartElementColor_ColorHex{
-					ColorHex: "#005072",
-				},
-			},
-			PointFillColor:   nil,
-			PointStrokeColor: nil,
-		},
-		BarLabelVisible:    nil,
-		BarLabelPosition:   0,
-		PointVisible:       &wrapperspb.BoolValue{Value: false},
-		PointType:          render.ChartView_X,
-		PointLabelVisible:  &wrapperspb.BoolValue{Value: false},
-		PointLabelPosition: render.ChartView_TOP,
-	}
-}
-
-func testingAreaViewWithDefaults() *render.ChartView {
-	res := testingAreaView()
-	res.Colors = testingColorsDefault()
-	res.Colors.FillColor = &render.ChartElementColor{
-		ColorValue: &render.ChartElementColor_ColorHex{
-			ColorHex: "#71c7ee",
-		},
-	}
-	res.Colors.StrokeColor = &render.ChartElementColor{
-		ColorValue: &render.ChartElementColor_ColorHex{
-			ColorHex: "#005072",
-		},
-	}
-	res.BarLabelVisible = &wrapperspb.BoolValue{Value: true}
-	res.BarLabelPosition = render.ChartView_CENTER
-
-	return res
-}
-
-func testingAreaViewBadRGBColor() *render.ChartView {
-	res := testingAreaView()
-	res.Colors = testingColorsDefault()
-	res.Colors.FillColor = &render.ChartElementColor{
-		ColorValue: &render.ChartElementColor_ColorRgb{
-			ColorRgb: &render.ChartElementColor_RGB{
-				R: 1,
-				G: 320,
-				B: 2,
-			},
-		},
-	}
-
-	return res
-}
-
-func testingLineView() *render.ChartView {
-	return &render.ChartView{
-		Kind: render.ChartView_LINE,
-		Values: &render.ChartView_ScalarValues{
-			ScalarValues: &render.ChartViewScalarValues{
-				Values: []float32{100, 200},
-			},
-		},
-		Colors:             nil,
-		BarLabelVisible:    nil,
-		BarLabelPosition:   0,
-		PointVisible:       &wrapperspb.BoolValue{Value: true},
-		PointType:          render.ChartView_SQUARE,
-		PointLabelVisible:  &wrapperspb.BoolValue{Value: true},
-		PointLabelPosition: render.ChartView_BOTTOM_RIGHT,
-	}
-}
-
-func testingLineViewWithDefaults() *render.ChartView {
-	res := testingLineView()
-	res.Colors = testingColorsDefault()
-	res.BarLabelVisible = &wrapperspb.BoolValue{Value: true}
-	res.BarLabelPosition = render.ChartView_CENTER
-
-	return res
-}
-
-func testingScatterView() *render.ChartView {
-	return &render.ChartView{
-		Kind: render.ChartView_SCATTER,
-		Values: &render.ChartView_PointsValues{
-			PointsValues: &render.ChartViewPointsValues{
-				Points: []*render.ChartViewPointsValues_Point{
-					{
-						X: 321,
-						Y: 8741,
-					},
-					{
-						X: 23,
-						Y: 85,
-					},
-				},
-			},
-		},
-		Colors:             nil,
-		BarLabelVisible:    nil,
-		BarLabelPosition:   0,
-		PointVisible:       &wrapperspb.BoolValue{Value: true},
-		PointType:          render.ChartView_CIRCLE,
-		PointLabelVisible:  &wrapperspb.BoolValue{Value: true},
-		PointLabelPosition: render.ChartView_TOP_LEFT,
-	}
-}
-
-func testingScatterViewWithDefaults() *render.ChartView {
-	res := testingScatterView()
-	res.Colors = testingColorsDefault()
-	res.BarLabelVisible = &wrapperspb.BoolValue{Value: true}
-	res.BarLabelPosition = render.ChartView_CENTER
-
-	return res
-}
-
-func testingVerticalBarView() *render.ChartView {
-	return &render.ChartView{
-		Kind: render.ChartView_VERTICAL_BAR,
-		Values: &render.ChartView_BarsValues{
-			BarsValues: &render.ChartViewBarsValues{
-				BarsDatasets: []*render.ChartViewBarsValues_BarsDataset{
-					{
-						Values: []float32{20, 30},
-						FillColor: &render.ChartElementColor{
-							ColorValue: &render.ChartElementColor_ColorHex{
-								ColorHex: "#bf0000",
-							},
-						},
-						StrokeColor: &render.ChartElementColor{
-							ColorValue: &render.ChartElementColor_ColorHex{
-								ColorHex: "#400000",
-							},
-						},
-					},
-				},
-			},
-		},
-		Colors:             nil,
-		BarLabelVisible:    &wrapperspb.BoolValue{Value: false},
-		BarLabelPosition:   render.ChartView_END_OUTSIDE,
-		PointVisible:       nil,
-		PointType:          0,
-		PointLabelVisible:  nil,
-		PointLabelPosition: 0,
-	}
-}
-
-func testingVerticalBarViewWithDefaults() *render.ChartView {
-	res := testingVerticalBarView()
-	res.Colors = testingColorsDefault()
-	res.PointVisible = &wrapperspb.BoolValue{Value: true}
-	res.PointType = render.ChartView_CIRCLE
-	res.PointLabelVisible = &wrapperspb.BoolValue{Value: true}
-	res.PointLabelPosition = render.ChartView_TOP
-
-	return res
-}
 
 func TestValidateChartViews(t *testing.T) {
 	t.Parallel()
@@ -279,37 +25,37 @@ func TestValidateChartViews(t *testing.T) {
 	}{
 		{
 			"vertical_bar_and_line",
-			[]*render.ChartView{testingVerticalBarView(), testingLineView()},
+			[]*render.ChartView{testutils.VerticalBarView(), testutils.LineView()},
 			render.ChartScale_BAND,
 			render.ChartScale_LINEAR,
-			[]*render.ChartView{testingVerticalBarViewWithDefaults(), testingLineViewWithDefaults()},
-			2,
+			[]*render.ChartView{testutils.VerticalBarViewWithDefaults(), testutils.LineViewWithDefaults()},
+			3,
 			nil,
 		},
 		{
 			"area",
-			[]*render.ChartView{testingAreaView()},
+			[]*render.ChartView{testutils.AreaView()},
 			render.ChartScale_BAND,
 			render.ChartScale_LINEAR,
-			[]*render.ChartView{testingAreaViewWithDefaults()},
+			[]*render.ChartView{testutils.AreaViewWithDefaults()},
 			2,
 			nil,
 		},
 		{
 			"horizontal_bar",
-			[]*render.ChartView{testingHorizontalBarView()},
+			[]*render.ChartView{testutils.HorizontalBarView()},
 			render.ChartScale_LINEAR,
 			render.ChartScale_BAND,
-			[]*render.ChartView{testingHorizontalBarViewWithDefaults()},
+			[]*render.ChartView{testutils.HorizontalBarViewWithDefaults()},
 			0,
 			nil,
 		},
 		{
 			"scatter",
-			[]*render.ChartView{testingScatterView()},
+			[]*render.ChartView{testutils.ScatterView()},
 			render.ChartScale_LINEAR,
 			render.ChartScale_LINEAR,
-			[]*render.ChartView{testingScatterViewWithDefaults()},
+			[]*render.ChartView{testutils.ScatterViewWithDefaults()},
 			0,
 			nil,
 		},
@@ -324,7 +70,7 @@ func TestValidateChartViews(t *testing.T) {
 		},
 		{
 			"unknown_view_kind",
-			[]*render.ChartView{testingChartUnspecifiedKind()},
+			[]*render.ChartView{testutils.UnspecifiedKindView()},
 			render.ChartScale_LINEAR,
 			render.ChartScale_LINEAR,
 			nil,
@@ -333,7 +79,7 @@ func TestValidateChartViews(t *testing.T) {
 		},
 		{
 			"view_without_values",
-			[]*render.ChartView{testingChartNoValues()},
+			[]*render.ChartView{testutils.HorizontalBarViewWithoutValues()},
 			render.ChartScale_LINEAR,
 			render.ChartScale_BAND,
 			nil,
@@ -342,7 +88,7 @@ func TestValidateChartViews(t *testing.T) {
 		},
 		{
 			"bad_categories_count",
-			[]*render.ChartView{testingAreaView()},
+			[]*render.ChartView{testutils.AreaView()},
 			render.ChartScale_BAND,
 			render.ChartScale_LINEAR,
 			nil,
@@ -351,7 +97,7 @@ func TestValidateChartViews(t *testing.T) {
 		},
 		{
 			"bad_rgb_value",
-			[]*render.ChartView{testingAreaViewBadRGBColor()},
+			[]*render.ChartView{testutils.AreaViewBadRGBColor()},
 			render.ChartScale_BAND,
 			render.ChartScale_LINEAR,
 			nil,
@@ -360,7 +106,7 @@ func TestValidateChartViews(t *testing.T) {
 		},
 		{
 			"area_with_bad_scales",
-			[]*render.ChartView{testingAreaView()},
+			[]*render.ChartView{testutils.AreaView()},
 			render.ChartScale_LINEAR,
 			render.ChartScale_LINEAR,
 			nil,
@@ -369,7 +115,7 @@ func TestValidateChartViews(t *testing.T) {
 		},
 		{
 			"horizontal_bar_with_bad_scales",
-			[]*render.ChartView{testingHorizontalBarView()},
+			[]*render.ChartView{testutils.HorizontalBarView()},
 			render.ChartScale_LINEAR,
 			render.ChartScale_LINEAR,
 			nil,
@@ -378,7 +124,7 @@ func TestValidateChartViews(t *testing.T) {
 		},
 		{
 			"line_with_bad_scales",
-			[]*render.ChartView{testingLineView()},
+			[]*render.ChartView{testutils.LineView()},
 			render.ChartScale_LINEAR,
 			render.ChartScale_LINEAR,
 			nil,
@@ -387,7 +133,7 @@ func TestValidateChartViews(t *testing.T) {
 		},
 		{
 			"scatter_with_bad_scales",
-			[]*render.ChartView{testingScatterView()},
+			[]*render.ChartView{testutils.ScatterView()},
 			render.ChartScale_LINEAR,
 			render.ChartScale_BAND,
 			nil,
@@ -396,7 +142,7 @@ func TestValidateChartViews(t *testing.T) {
 		},
 		{
 			"vertical_bar_with_bad_scales",
-			[]*render.ChartView{testingVerticalBarView()},
+			[]*render.ChartView{testutils.VerticalBarView()},
 			render.ChartScale_LINEAR,
 			render.ChartScale_BAND,
 			nil,


### PR DESCRIPTION
Move common render.Chart* structs to `testutils` package.