### PR TITLE
Add jsontoapi and rgb validators

### DIFF
--- a/internal/validate/apitorenderer/chart_axes.go
+++ b/internal/validate/apitorenderer/chart_axes.go
@@ -2,6 +2,7 @@ package apitorenderer
 
 import (
 	"errors"
+	"fmt"
 
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -12,9 +13,14 @@ const (
 	rangeStartDefault = 0
 
 	paddingDefault = 0.1
+
+	labelMaxLen = 1024
 )
 
 var (
+	// ErrLabelMaxLen contains error message about max label len.
+	ErrLabelMaxLen = fmt.Errorf("label max len is %d", labelMaxLen)
+
 	// ErrChartAxesAreNotSpecified contains error message about not specified chart axes.
 	ErrChartAxesAreNotSpecified = errors.New("chart axes are not specified")
 
@@ -68,6 +74,10 @@ var (
 func ValidateChartAxes(chartAxes *render.ChartAxes, chartSizes *render.ChartSizes, chartMargins *render.ChartMargins) (*render.ChartAxes, error) {
 	if chartAxes == nil {
 		return nil, ErrChartAxesAreNotSpecified
+	}
+
+	if err := validateAxesLabels(chartAxes); err != nil {
+		return nil, err
 	}
 
 	if err := validateTopAndBottomAxesKinds(chartAxes); err != nil {
@@ -306,4 +316,24 @@ func setChartScaleDefaultPaddings(chartScale *render.ChartScale) *render.ChartSc
 	}
 
 	return chartScale
+}
+
+func validateAxesLabels(chartAxes *render.ChartAxes) error {
+	if len(chartAxes.AxisTopLabel) > labelMaxLen {
+		return ErrLabelMaxLen
+	}
+
+	if len(chartAxes.AxisBottomLabel) > labelMaxLen {
+		return ErrLabelMaxLen
+	}
+
+	if len(chartAxes.AxisLeftLabel) > labelMaxLen {
+		return ErrLabelMaxLen
+	}
+
+	if len(chartAxes.AxisRightLabel) > labelMaxLen {
+		return ErrLabelMaxLen
+	}
+
+	return nil
 }

--- a/internal/validate/apitorenderer/chart_axes_test.go
+++ b/internal/validate/apitorenderer/chart_axes_test.go
@@ -253,6 +253,23 @@ func TestValidateChartAxes(t *testing.T) {
 			nil,
 			apitorenderer.ErrChartBandScaleDomainShouldBeSpecified,
 		},
+		{
+			"too big scale label",
+			&render.ChartAxes{
+				AxisTop:         testutils.LinearChartScale(),
+				AxisTopLabel:    testutils.RandomString(1025),
+				AxisBottom:      testutils.LinearChartScale(),
+				AxisBottomLabel: "b",
+				AxisLeft:        testutils.BandChartScale(),
+				AxisLeftLabel:   "l",
+				AxisRight:       testutils.BandChartScale(),
+				AxisRightLabel:  "r",
+			},
+			nil,
+			nil,
+			nil,
+			apitorenderer.ErrLabelMaxLen,
+		},
 	}
 
 	for _, tc := range tt {

--- a/internal/validate/apitorenderer/chart_colors.go
+++ b/internal/validate/apitorenderer/chart_colors.go
@@ -1,0 +1,95 @@
+package apitorenderer
+
+import (
+	"fmt"
+
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/validate/rgb"
+)
+
+const (
+	fillColorDefault   = "#71c7ec"
+	strokeColorDefault = "#005073"
+)
+
+func validateViewColors(chartView *render.ChartView) (*render.ChartView, error) {
+	defaultColors := defaultViewColors()
+
+	if chartView.Colors == nil {
+		chartView.Colors = defaultColors
+
+		return chartView, nil
+	}
+
+	fillColor, err := validateChartElementColor(chartView.Colors.FillColor, defaultColors.FillColor)
+	if err != nil {
+		return nil, err
+	}
+
+	strokeColor, err := validateChartElementColor(chartView.Colors.StrokeColor, defaultColors.StrokeColor)
+	if err != nil {
+		return nil, err
+	}
+
+	pointFillColor, err := validateChartElementColor(chartView.Colors.PointFillColor, defaultColors.PointFillColor)
+	if err != nil {
+		return nil, err
+	}
+
+	pointStrokeColor, err := validateChartElementColor(chartView.Colors.PointStrokeColor, defaultColors.PointStrokeColor)
+	if err != nil {
+		return nil, err
+	}
+
+	chartView.Colors.FillColor = fillColor
+	chartView.Colors.StrokeColor = strokeColor
+	chartView.Colors.PointFillColor = pointFillColor
+	chartView.Colors.PointStrokeColor = pointStrokeColor
+
+	return chartView, nil
+}
+
+func validateChartElementColor(chartElementColor *render.ChartElementColor, defaultColor *render.ChartElementColor) (*render.ChartElementColor, error) {
+	if chartElementColor == nil {
+		return defaultColor, nil
+	}
+
+	if chartElementColor.GetColorHex() == "" && chartElementColor.GetColorRgb() == nil {
+		return defaultColor, nil
+	}
+
+	if chartElementColor.GetColorHex() != "" {
+		return chartElementColor, nil
+	}
+
+	if err := rgb.ValidateChartElementColor(chartElementColor); err != nil {
+		return nil, fmt.Errorf("unable to validate rgb chart element color: %w", err)
+	}
+
+	return chartElementColor, nil
+}
+
+func defaultViewColors() *render.ChartViewColors {
+	return &render.ChartViewColors{
+		FillColor: &render.ChartElementColor{
+			ColorValue: &render.ChartElementColor_ColorHex{
+				ColorHex: fillColorDefault,
+			},
+		},
+		StrokeColor: &render.ChartElementColor{
+			ColorValue: &render.ChartElementColor_ColorHex{
+				ColorHex: strokeColorDefault,
+			},
+		},
+		PointFillColor: &render.ChartElementColor{
+			ColorValue: &render.ChartElementColor_ColorHex{
+				ColorHex: fillColorDefault,
+			},
+		},
+		PointStrokeColor: &render.ChartElementColor{
+			ColorValue: &render.ChartElementColor_ColorHex{
+				ColorHex: strokeColorDefault,
+			},
+		},
+	}
+}

--- a/internal/validate/apitorenderer/chart_title.go
+++ b/internal/validate/apitorenderer/chart_title.go
@@ -1,0 +1,17 @@
+package apitorenderer
+
+import "fmt"
+
+const titleMaxLen = 1024
+
+// ErrTitleMaxLen contains error message about max title len.
+var ErrTitleMaxLen = fmt.Errorf("title max len is %d", titleMaxLen)
+
+// ValidateChartTitle validates the provided title.
+func ValidateChartTitle(title string) error {
+	if len(title) > titleMaxLen {
+		return ErrTitleMaxLen
+	}
+
+	return nil
+}

--- a/internal/validate/apitorenderer/chart_title_test.go
+++ b/internal/validate/apitorenderer/chart_title_test.go
@@ -1,0 +1,46 @@
+package apitorenderer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/limpidchart/lc-api/internal/testutils"
+	"github.com/limpidchart/lc-api/internal/validate/apitorenderer"
+)
+
+func TestValidateChartTitle(t *testing.T) {
+	t.Parallel()
+
+	//nolint: govet
+	tt := []struct {
+		name        string
+		title       string
+		expectedErr error
+	}{
+		{
+			"empty",
+			"",
+			nil,
+		},
+		{
+			"small len",
+			"my chart",
+			nil,
+		},
+		{
+			"too big len",
+			testutils.RandomString(1025),
+			apitorenderer.ErrTitleMaxLen,
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actualErr := apitorenderer.ValidateChartTitle(tc.title)
+			assert.Equal(t, tc.expectedErr, actualErr)
+		})
+	}
+}

--- a/internal/validate/apitorenderer/chart_views_test.go
+++ b/internal/validate/apitorenderer/chart_views_test.go
@@ -1,6 +1,7 @@
 package apitorenderer_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +9,7 @@ import (
 	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
 	"github.com/limpidchart/lc-api/internal/testutils"
 	"github.com/limpidchart/lc-api/internal/validate/apitorenderer"
+	"github.com/limpidchart/lc-api/internal/validate/rgb"
 )
 
 func TestValidateChartViews(t *testing.T) {
@@ -102,7 +104,7 @@ func TestValidateChartViews(t *testing.T) {
 			render.ChartScale_LINEAR,
 			nil,
 			2,
-			apitorenderer.ErrChartElementColorRGBBadValue,
+			fmt.Errorf("unable to validate rgb chart element color: %w", rgb.ErrChartElementColorRGBBadValue),
 		},
 		{
 			"area_with_bad_scales",

--- a/internal/validate/jsontoapi/chart_axes.go
+++ b/internal/validate/jsontoapi/chart_axes.go
@@ -1,0 +1,104 @@
+package jsontoapi
+
+import (
+	"errors"
+	"strings"
+
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/serverrest/view/v0"
+)
+
+const (
+	scaleLinearKind = "linear"
+	scaleBandKind   = "band"
+)
+
+// ErrOnlyOneOfDomainsShouldBeSpecified contains error message about a case when too many domains are provided.
+var ErrOnlyOneOfDomainsShouldBeSpecified = errors.New("only one of domain_numeric or domain_categories should be specified")
+
+// ChartScaleFromJSON parses and validates JSON chart scale representation.
+func ChartScaleFromJSON(scale *view.ChartScale) (*render.ChartScale, error) {
+	if scale == nil {
+		return nil, nil
+	}
+
+	if scale.DomainNumeric != nil && scale.DomainCategories != nil {
+		return nil, ErrOnlyOneOfDomainsShouldBeSpecified
+	}
+
+	result := emptyChartScale()
+
+	if scale.DomainNumeric != nil {
+		result.Domain = &render.ChartScale_DomainNumeric{
+			DomainNumeric: &render.DomainNumeric{
+				Start: scale.DomainNumeric.Start,
+				End:   scale.DomainNumeric.End,
+			},
+		}
+	}
+
+	if scale.DomainCategories != nil {
+		result.Domain = &render.ChartScale_DomainCategories{
+			DomainCategories: &render.DomainCategories{
+				Categories: scale.DomainCategories.Categories,
+			},
+		}
+	}
+
+	var (
+		rangeStart   *wrapperspb.Int32Value
+		rangeEnd     *wrapperspb.Int32Value
+		innerPadding *wrapperspb.FloatValue
+		outerPadding *wrapperspb.FloatValue
+	)
+
+	if scale.RangeStart != nil {
+		rangeStart = &wrapperspb.Int32Value{Value: int32(*scale.RangeStart)}
+	}
+
+	if scale.RangeEnd != nil {
+		rangeEnd = &wrapperspb.Int32Value{Value: int32(*scale.RangeEnd)}
+	}
+
+	if scale.InnerPadding != nil {
+		innerPadding = &wrapperspb.FloatValue{Value: *scale.InnerPadding}
+	}
+
+	if scale.OuterPadding != nil {
+		outerPadding = &wrapperspb.FloatValue{Value: *scale.OuterPadding}
+	}
+
+	result.Kind = scaleKindFromJSON(scale.Kind)
+	result.RangeStart = rangeStart
+	result.RangeEnd = rangeEnd
+	result.NoBoundariesOffset = scale.NoBoundariesOffset
+	result.InnerPadding = innerPadding
+	result.OuterPadding = outerPadding
+
+	return result, nil
+}
+
+func emptyChartScale() *render.ChartScale {
+	return &render.ChartScale{
+		Kind:               0,
+		RangeStart:         nil,
+		RangeEnd:           nil,
+		Domain:             nil,
+		NoBoundariesOffset: false,
+		InnerPadding:       nil,
+		OuterPadding:       nil,
+	}
+}
+
+func scaleKindFromJSON(kind string) render.ChartScale_ChartScaleKind {
+	switch strings.ToLower(kind) {
+	case scaleLinearKind:
+		return render.ChartScale_LINEAR
+	case scaleBandKind:
+		return render.ChartScale_BAND
+	default:
+		return render.ChartScale_UNSPECIFIED_SCALE
+	}
+}

--- a/internal/validate/jsontoapi/chart_axes_test.go
+++ b/internal/validate/jsontoapi/chart_axes_test.go
@@ -1,0 +1,66 @@
+package jsontoapi_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/serverrest/view/v0"
+	"github.com/limpidchart/lc-api/internal/testutils"
+	"github.com/limpidchart/lc-api/internal/validate/jsontoapi"
+)
+
+func TestChartScaleFromJSON(t *testing.T) {
+	t.Parallel()
+
+	//nolint: govet
+	tt := []struct {
+		name          string
+		chartScale    *view.ChartScale
+		expectedScale *render.ChartScale
+		expectedErr   error
+	}{
+		{
+			"empty",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"band_scale",
+			testutils.JSONBandChartScale(),
+			testutils.BandChartScale(),
+			nil,
+		},
+		{
+			"linear_scale",
+			testutils.JSONLinearChartScale(),
+			testutils.LinearChartScale(),
+			nil,
+		},
+		{
+			"band_scale_with_no_boundaries_offset",
+			testutils.JSONBandChartScaleWithNoBoundariesOffset(),
+			testutils.BandChartScaleWithNoBoundariesOffset(),
+			nil,
+		},
+		{
+			"band_scale_with_two_domains",
+			testutils.JSONBandChartScaleTwoDomains(),
+			nil,
+			jsontoapi.ErrOnlyOneOfDomainsShouldBeSpecified,
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actualScale, actualErr := jsontoapi.ChartScaleFromJSON(tc.chartScale)
+			assert.Equal(t, actualScale, tc.expectedScale)
+			assert.Equal(t, actualErr, tc.expectedErr)
+		})
+	}
+}

--- a/internal/validate/jsontoapi/chart_colors.go
+++ b/internal/validate/jsontoapi/chart_colors.go
@@ -1,0 +1,75 @@
+package jsontoapi
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/serverrest/view/v0"
+	"github.com/limpidchart/lc-api/internal/validate/rgb"
+)
+
+// ErrOnlyOneOfHexOrRGBColorShouldBeSpecified contains error message about bad color value.
+var ErrOnlyOneOfHexOrRGBColorShouldBeSpecified = errors.New("color can be only one of hex or rgb")
+
+func viewColorsFromJSON(colors *view.ChartViewColors) (*render.ChartViewColors, error) {
+	if colors == nil {
+		return nil, nil
+	}
+
+	fillColor, err := chartElementColorFromJSON(colors.FillColor)
+	if err != nil {
+		return nil, err
+	}
+
+	strokeColor, err := chartElementColorFromJSON(colors.StrokeColor)
+	if err != nil {
+		return nil, err
+	}
+
+	pointFillColor, err := chartElementColorFromJSON(colors.PointFillColor)
+	if err != nil {
+		return nil, err
+	}
+
+	pointStrokeColor, err := chartElementColorFromJSON(colors.PointStrokeColor)
+	if err != nil {
+		return nil, err
+	}
+
+	return &render.ChartViewColors{
+		FillColor:        fillColor,
+		StrokeColor:      strokeColor,
+		PointFillColor:   pointFillColor,
+		PointStrokeColor: pointStrokeColor,
+	}, nil
+}
+
+func chartElementColorFromJSON(color *view.ChartElementColor) (*render.ChartElementColor, error) {
+	if color == nil {
+		return nil, nil
+	}
+
+	if color.Hex == "" && color.RGB == nil {
+		return nil, nil
+	}
+
+	if color.Hex != "" && color.RGB != nil {
+		return nil, ErrOnlyOneOfHexOrRGBColorShouldBeSpecified
+	}
+
+	if color.Hex != "" {
+		return &render.ChartElementColor{
+			ColorValue: &render.ChartElementColor_ColorHex{
+				ColorHex: color.Hex,
+			},
+		}, nil
+	}
+
+	rgbColor, err := rgb.ValidateChartElementColorJSON(color)
+	if err != nil {
+		return nil, fmt.Errorf("unable to validate rgb chart element color: %w", err)
+	}
+
+	return rgbColor, nil
+}

--- a/internal/validate/jsontoapi/chart_views.go
+++ b/internal/validate/jsontoapi/chart_views.go
@@ -1,0 +1,269 @@
+package jsontoapi
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/serverrest/view/v0"
+)
+
+const pointValuesCount = 2
+
+var (
+	// ErrViewIsEmpty contains error message about empty view.
+	ErrViewIsEmpty = errors.New("chart view is empty")
+
+	// ErrOnlyOneOfValuesKindShouldBeSpecified contains error message about a case when too many values kinds are provided.
+	ErrOnlyOneOfValuesKindShouldBeSpecified = errors.New("only one of bars_values, points_values, scalar_values should be specified")
+
+	// ErrBadPointValuesCount contains error message about bad point.
+	ErrBadPointValuesCount = fmt.Errorf("each point should have %d values", pointValuesCount)
+)
+
+const (
+	viewAreaKind          = "area"
+	viewHorizontalBarKind = "horizontal_bar"
+	viewLineKind          = "line"
+	viewScatterKind       = "scatter"
+	viewVerticalBarKind   = "vertical_bar"
+
+	barLabelPositionStartOutside = "start_outside"
+	barLabelPositionStartInside  = "start_inside"
+	barLabelPositionCenter       = "center"
+	barLabelPositionEndInside    = "end_inside"
+	barLabelPositionEndOutside   = "end_outside"
+
+	pointTypeCircle = "circle"
+	pointTypeSquare = "square"
+	pointTypeX      = "x"
+
+	pointLabelPositionTop         = "top"
+	pointLabelPositionTopRight    = "top_right"
+	pointLabelPositionTopLeft     = "top_left"
+	pointLabelPositionLeft        = "left"
+	pointLabelPositionRight       = "right"
+	pointLabelPositionBottom      = "bottom"
+	pointLabelPositionBottomLeft  = "bottom_left"
+	pointLabelPositionBottomRight = "bottom_right"
+
+	barLabelVisibleDefault   = true
+	pointVisibleDefault      = true
+	pointLabelVisibleDefault = true
+)
+
+// ChartViewFromJSON parses and validates chart view JSON representation.
+func ChartViewFromJSON(jsonView *view.ChartView) (*render.ChartView, error) {
+	if jsonView == nil {
+		return nil, ErrViewIsEmpty
+	}
+
+	var (
+		barLabelVisible   bool
+		pointVisible      bool
+		pointLabelVisible bool
+	)
+
+	if jsonView.BarLabelVisible == nil {
+		barLabelVisible = barLabelVisibleDefault
+	} else {
+		barLabelVisible = *jsonView.BarLabelVisible
+	}
+
+	if jsonView.PointVisible == nil {
+		pointVisible = pointVisibleDefault
+	} else {
+		pointVisible = *jsonView.PointVisible
+	}
+
+	if jsonView.PointLabelVisible == nil {
+		pointLabelVisible = pointLabelVisibleDefault
+	} else {
+		pointLabelVisible = *jsonView.PointLabelVisible
+	}
+
+	colors, err := viewColorsFromJSON(jsonView.Colors)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &render.ChartView{
+		Kind:               viewKindFromJSON(jsonView.Kind),
+		Values:             nil,
+		Colors:             colors,
+		BarLabelVisible:    &wrapperspb.BoolValue{Value: barLabelVisible},
+		BarLabelPosition:   barLabelPositionFromJSON(jsonView.BarLabelPosition),
+		PointVisible:       &wrapperspb.BoolValue{Value: pointVisible},
+		PointType:          pointTypeFromJSON(jsonView.PointType),
+		PointLabelVisible:  &wrapperspb.BoolValue{Value: pointLabelVisible},
+		PointLabelPosition: pointLabelPositionFromJSON(jsonView.PointLabelPosition),
+	}
+
+	valuesAreSet := false
+
+	if jsonView.BarsValues != nil {
+		barsValues, err := barsValuesFromJSON(jsonView)
+		if err != nil {
+			return nil, err
+		}
+
+		result.Values = &render.ChartView_BarsValues{
+			BarsValues: barsValues,
+		}
+
+		valuesAreSet = true
+	}
+
+	if jsonView.PointsValues != nil {
+		if valuesAreSet {
+			return nil, ErrOnlyOneOfValuesKindShouldBeSpecified
+		}
+
+		pointsValues, err := pointValuesFromJSON(jsonView)
+		if err != nil {
+			return nil, err
+		}
+
+		result.Values = &render.ChartView_PointsValues{
+			PointsValues: pointsValues,
+		}
+
+		valuesAreSet = true
+	}
+
+	if jsonView.ScalarValues != nil {
+		if valuesAreSet {
+			return nil, ErrOnlyOneOfValuesKindShouldBeSpecified
+		}
+
+		result.Values = &render.ChartView_ScalarValues{
+			ScalarValues: scalarValuesFromJSON(jsonView),
+		}
+	}
+
+	return result, nil
+}
+
+func viewKindFromJSON(kind string) render.ChartView_ChartViewKind {
+	switch strings.ToLower(kind) {
+	case viewAreaKind:
+		return render.ChartView_AREA
+	case viewHorizontalBarKind:
+		return render.ChartView_HORIZONTAL_BAR
+	case viewLineKind:
+		return render.ChartView_LINE
+	case viewScatterKind:
+		return render.ChartView_SCATTER
+	case viewVerticalBarKind:
+		return render.ChartView_VERTICAL_BAR
+	default:
+		return render.ChartView_UNSPECIFIED_KIND
+	}
+}
+
+func barLabelPositionFromJSON(position string) render.ChartView_ChartViewBarLabelPosition {
+	switch strings.ToLower(position) {
+	case barLabelPositionStartOutside:
+		return render.ChartView_START_OUTSIDE
+	case barLabelPositionStartInside:
+		return render.ChartView_START_INSIDE
+	case barLabelPositionCenter:
+		return render.ChartView_CENTER
+	case barLabelPositionEndInside:
+		return render.ChartView_END_INSIDE
+	case barLabelPositionEndOutside:
+		return render.ChartView_END_OUTSIDE
+	default:
+		return render.ChartView_UNSPECIFIED_BAR_LABEL_POSITION
+	}
+}
+
+func pointTypeFromJSON(pointType string) render.ChartView_ChartViewPointType {
+	switch strings.ToLower(pointType) {
+	case pointTypeCircle:
+		return render.ChartView_CIRCLE
+	case pointTypeSquare:
+		return render.ChartView_SQUARE
+	case pointTypeX:
+		return render.ChartView_X
+	default:
+		return render.ChartView_UNSPECIFIED_POINT_TYPE
+	}
+}
+
+func pointLabelPositionFromJSON(position string) render.ChartView_ChartViewPointLabelPosition {
+	switch strings.ToLower(position) {
+	case pointLabelPositionTop:
+		return render.ChartView_TOP
+	case pointLabelPositionTopRight:
+		return render.ChartView_TOP_RIGHT
+	case pointLabelPositionTopLeft:
+		return render.ChartView_TOP_LEFT
+	case pointLabelPositionLeft:
+		return render.ChartView_LEFT
+	case pointLabelPositionRight:
+		return render.ChartView_RIGHT
+	case pointLabelPositionBottom:
+		return render.ChartView_BOTTOM
+	case pointLabelPositionBottomLeft:
+		return render.ChartView_BOTTOM_LEFT
+	case pointLabelPositionBottomRight:
+		return render.ChartView_BOTTOM_RIGHT
+	default:
+		return render.ChartView_UNSPECIFIED_POINT_LABEL_POSITION
+	}
+}
+
+func pointValuesFromJSON(jsonView *view.ChartView) (*render.ChartViewPointsValues, error) {
+	points := make([]*render.ChartViewPointsValues_Point, 0, len(jsonView.PointsValues.Values))
+
+	for _, point := range jsonView.PointsValues.Values {
+		if len(point) != pointValuesCount {
+			return nil, ErrBadPointValuesCount
+		}
+
+		points = append(points, &render.ChartViewPointsValues_Point{
+			X: point[0],
+			Y: point[1],
+		})
+	}
+
+	return &render.ChartViewPointsValues{
+		Points: points,
+	}, nil
+}
+
+func scalarValuesFromJSON(jsonView *view.ChartView) *render.ChartViewScalarValues {
+	return &render.ChartViewScalarValues{
+		Values: jsonView.ScalarValues.Values,
+	}
+}
+
+func barsValuesFromJSON(jsonView *view.ChartView) (*render.ChartViewBarsValues, error) {
+	barsDatasets := make([]*render.ChartViewBarsValues_BarsDataset, 0, len(jsonView.BarsValues))
+
+	for _, barsValue := range jsonView.BarsValues {
+		fillColor, err := chartElementColorFromJSON(barsValue.FillColor)
+		if err != nil {
+			return nil, err
+		}
+
+		strokeColor, err := chartElementColorFromJSON(barsValue.StrokeColor)
+		if err != nil {
+			return nil, err
+		}
+
+		barsDatasets = append(barsDatasets, &render.ChartViewBarsValues_BarsDataset{
+			Values:      barsValue.Values,
+			FillColor:   fillColor,
+			StrokeColor: strokeColor,
+		})
+	}
+
+	return &render.ChartViewBarsValues{
+		BarsDatasets: barsDatasets,
+	}, nil
+}

--- a/internal/validate/jsontoapi/chart_views_test.go
+++ b/internal/validate/jsontoapi/chart_views_test.go
@@ -1,0 +1,84 @@
+package jsontoapi_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/serverrest/view/v0"
+	"github.com/limpidchart/lc-api/internal/testutils"
+	"github.com/limpidchart/lc-api/internal/validate/jsontoapi"
+)
+
+func TestChartViewFromJSON(t *testing.T) {
+	t.Parallel()
+
+	//nolint: govet
+	tt := []struct {
+		name         string
+		chartView    *view.ChartView
+		expectedView *render.ChartView
+		expectedErr  error
+	}{
+		{
+			"horizontal_bar",
+			testutils.JSONHorizontalBarView(),
+			testutils.HorizontalBarViewWithBoolDefaults(),
+			nil,
+		},
+		{
+			"area",
+			testutils.JSONAreaView(),
+			testutils.AreaViewWithBoolDefaults(),
+			nil,
+		},
+		{
+			"empty",
+			nil,
+			nil,
+			jsontoapi.ErrViewIsEmpty,
+		},
+		{
+			"scalar_and_bars_values",
+			testutils.JSONHorizontalBarViewWithScalarAndBarsValues(),
+			nil,
+			jsontoapi.ErrOnlyOneOfValuesKindShouldBeSpecified,
+		},
+		{
+			"scalar_and_points_values",
+			testutils.JSONHorizontalBarViewWithScalarAndPointsValues(),
+			nil,
+			jsontoapi.ErrOnlyOneOfValuesKindShouldBeSpecified,
+		},
+		{
+			"points_and_bars_values",
+			testutils.JSONHorizontalBarViewWithPointsAndBarsValues(),
+			nil,
+			jsontoapi.ErrOnlyOneOfValuesKindShouldBeSpecified,
+		},
+		{
+			"all_values",
+			testutils.JSONHorizontalBarViewWithAllValues(),
+			nil,
+			jsontoapi.ErrOnlyOneOfValuesKindShouldBeSpecified,
+		},
+		{
+			"bad_points_count",
+			testutils.JSONAreaViewBadPointsCount(),
+			nil,
+			jsontoapi.ErrBadPointValuesCount,
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actualView, actualErr := jsontoapi.ChartViewFromJSON(tc.chartView)
+			assert.Equal(t, tc.expectedView, actualView)
+			assert.Equal(t, tc.expectedErr, actualErr)
+		})
+	}
+}

--- a/internal/validate/rgb/rgb.go
+++ b/internal/validate/rgb/rgb.go
@@ -1,0 +1,80 @@
+package rgb
+
+import (
+	"fmt"
+
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/serverrest/view/v0"
+)
+
+const (
+	minValue = 0
+
+	maxValue = 255
+)
+
+// ErrChartElementColorRGBBadValue contains error message about bad RGB value.
+var ErrChartElementColorRGBBadValue = fmt.Errorf("chart element color RGB value should be between %d and %d if it's set", minValue, maxValue)
+
+// ValidateChartElementColor validates if chart element color can be used as RGB color.
+func ValidateChartElementColor(chartElementColor *render.ChartElementColor) error {
+	colorRGB := chartElementColor.GetColorRgb()
+
+	if colorRGB == nil {
+		return nil
+	}
+
+	if err := uint32ColorValue(colorRGB.R); err != nil {
+		return err
+	}
+
+	if err := uint32ColorValue(colorRGB.G); err != nil {
+		return err
+	}
+
+	return uint32ColorValue(colorRGB.B)
+}
+
+// ValidateChartElementColorJSON parses and validates chart element color JSON representation.
+func ValidateChartElementColorJSON(color *view.ChartElementColor) (*render.ChartElementColor, error) {
+	r, err := intColorValue(color.RGB.R)
+	if err != nil {
+		return nil, err
+	}
+
+	g, err := intColorValue(color.RGB.G)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := intColorValue(color.RGB.B)
+	if err != nil {
+		return nil, err
+	}
+
+	return &render.ChartElementColor{
+		ColorValue: &render.ChartElementColor_ColorRgb{
+			ColorRgb: &render.ChartElementColor_RGB{
+				R: r,
+				G: g,
+				B: b,
+			},
+		},
+	}, nil
+}
+
+func uint32ColorValue(value uint32) error {
+	if value < minValue || value > maxValue {
+		return ErrChartElementColorRGBBadValue
+	}
+
+	return nil
+}
+
+func intColorValue(value int) (uint32, error) {
+	if value < minValue || value > maxValue {
+		return 0, ErrChartElementColorRGBBadValue
+	}
+
+	return uint32(value), nil
+}

--- a/internal/validate/rgb/rgb_test.go
+++ b/internal/validate/rgb/rgb_test.go
@@ -1,0 +1,208 @@
+package rgb_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/serverrest/view/v0"
+	"github.com/limpidchart/lc-api/internal/validate/rgb"
+)
+
+func TestChartElementColor(t *testing.T) {
+	t.Parallel()
+
+	//nolint: govet
+	tt := []struct {
+		name              string
+		chartElementColor *render.ChartElementColor
+		expectedErr       error
+	}{
+		{
+			"good rgb",
+			&render.ChartElementColor{
+				ColorValue: &render.ChartElementColor_ColorRgb{
+					ColorRgb: &render.ChartElementColor_RGB{
+						R: 100,
+						G: 125,
+						B: 150,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"too_big_r",
+			&render.ChartElementColor{
+				ColorValue: &render.ChartElementColor_ColorRgb{
+					ColorRgb: &render.ChartElementColor_RGB{
+						R: 1000,
+						G: 125,
+						B: 150,
+					},
+				},
+			},
+			rgb.ErrChartElementColorRGBBadValue,
+		},
+		{
+			"too_big_g",
+			&render.ChartElementColor{
+				ColorValue: &render.ChartElementColor_ColorRgb{
+					ColorRgb: &render.ChartElementColor_RGB{
+						R: 100,
+						G: 1250,
+						B: 150,
+					},
+				},
+			},
+			rgb.ErrChartElementColorRGBBadValue,
+		},
+		{
+			"too_big_b",
+			&render.ChartElementColor{
+				ColorValue: &render.ChartElementColor_ColorRgb{
+					ColorRgb: &render.ChartElementColor_RGB{
+						R: 100,
+						G: 125,
+						B: 1500,
+					},
+				},
+			},
+			rgb.ErrChartElementColorRGBBadValue,
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actualErr := rgb.ValidateChartElementColor(tc.chartElementColor)
+			assert.Equal(t, tc.expectedErr, actualErr)
+		})
+	}
+}
+
+func TestValidateChartElementColorJSON(t *testing.T) {
+	t.Parallel()
+
+	//nolint: govet
+	tt := []struct {
+		name              string
+		chartElementColor *view.ChartElementColor
+		expectedColor     *render.ChartElementColor
+		expectedErr       error
+	}{
+		{
+			"good rgb",
+			&view.ChartElementColor{
+				Hex: "",
+				RGB: &view.RGB{
+					R: 10,
+					G: 25,
+					B: 50,
+				},
+			},
+			&render.ChartElementColor{
+				ColorValue: &render.ChartElementColor_ColorRgb{
+					ColorRgb: &render.ChartElementColor_RGB{
+						R: 10,
+						G: 25,
+						B: 50,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"too_small_r",
+			&view.ChartElementColor{
+				Hex: "",
+				RGB: &view.RGB{
+					R: -10,
+					G: 25,
+					B: 50,
+				},
+			},
+			nil,
+			rgb.ErrChartElementColorRGBBadValue,
+		},
+		{
+			"too_small_g",
+			&view.ChartElementColor{
+				Hex: "",
+				RGB: &view.RGB{
+					R: 10,
+					G: -25,
+					B: 50,
+				},
+			},
+			nil,
+			rgb.ErrChartElementColorRGBBadValue,
+		},
+		{
+			"too_small_b",
+			&view.ChartElementColor{
+				Hex: "",
+				RGB: &view.RGB{
+					R: 10,
+					G: 25,
+					B: -50,
+				},
+			},
+			nil,
+			rgb.ErrChartElementColorRGBBadValue,
+		},
+		{
+			"too_big_r",
+			&view.ChartElementColor{
+				Hex: "",
+				RGB: &view.RGB{
+					R: 1000,
+					G: 25,
+					B: 50,
+				},
+			},
+			nil,
+			rgb.ErrChartElementColorRGBBadValue,
+		},
+		{
+			"too_big_g",
+			&view.ChartElementColor{
+				Hex: "",
+				RGB: &view.RGB{
+					R: 10,
+					G: 2500,
+					B: 50,
+				},
+			},
+			nil,
+			rgb.ErrChartElementColorRGBBadValue,
+		},
+		{
+			"too_big_b",
+			&view.ChartElementColor{
+				Hex: "",
+				RGB: &view.RGB{
+					R: 10,
+					G: 25,
+					B: 5000,
+				},
+			},
+			nil,
+			rgb.ErrChartElementColorRGBBadValue,
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			actualColor, actualErr := rgb.ValidateChartElementColorJSON(tc.chartElementColor)
+			assert.Equal(t, tc.expectedColor, actualColor)
+			assert.Equal(t, tc.expectedErr, actualErr)
+		})
+	}
+}


### PR DESCRIPTION
Add validators to convert and validate JSON views into render proto
structs.

Move rgb color validation into its own package.