### PR TITLE
Refactor gRPC server

### DIFF
--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -1,0 +1,120 @@
+package renderer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+
+	"github.com/limpidchart/lc-api/internal/config"
+	"github.com/limpidchart/lc-api/internal/convert"
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+)
+
+const rendererServiceCfg = `{"loadBalancingPolicy":"round_robin"}`
+
+var (
+	// ErrCreateChartRequestCancelled contains error message about cancelled create chart request.
+	ErrCreateChartRequestCancelled = errors.New("create chart request is cancelled")
+
+	// ErrGenerateChartIDFailed contains error message about failed chart ID generation.
+	ErrGenerateChartIDFailed = errors.New("unable to generate a random UUID for chart ID")
+)
+
+// NewConn creates a new lc-renderer connection.
+func NewConn(ctx context.Context, rendererCfg config.RendererConfig) (*grpc.ClientConn, error) {
+	rendererConnCtx, rendererConnCancel := context.WithTimeout(ctx, time.Second*time.Duration(rendererCfg.ConnTimeoutSeconds))
+	defer rendererConnCancel()
+
+	rendererConn, err := grpc.DialContext(
+		rendererConnCtx,
+		rendererCfg.Address,
+		grpc.WithInsecure(),
+		grpc.WithBlock(),
+		grpc.WithDefaultServiceConfig(rendererServiceCfg),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connection to lc-renderer: %w", err)
+	}
+
+	return rendererConn, nil
+}
+
+// CreateChartOpts represents options for CreateChart method.
+type CreateChartOpts struct {
+	RequestID      string
+	Request        *render.CreateChartRequest
+	RendererClient render.ChartRendererClient
+	Timeout        time.Duration
+}
+
+// CreateChart converts render.CreateChartRequest and requests a chart rendering from lc-renderer.
+//
+// Note: tests are implemented in internal/servergrpc package.
+func CreateChart(ctx context.Context, opts CreateChartOpts) (*render.ChartReply, error) {
+	now := time.Now().UTC()
+
+	renderChartReq, err := convert.CreateChartRequestToRenderChartRequest(opts.Request)
+	if err != nil {
+		return nil, err
+	}
+
+	renderChartReq.RequestId = opts.RequestID
+
+	rendererCtx, rendererCancel := context.WithTimeout(ctx, opts.Timeout)
+	defer rendererCancel()
+
+	select {
+	case <-ctx.Done():
+		return nil, ErrCreateChartRequestCancelled
+	case renderResult := <-renderChart(rendererCtx, opts.RendererClient, renderChartReq):
+		switch {
+		case isTimedOutErr(renderResult.err):
+			return nil, ErrCreateChartRequestCancelled
+		case renderResult.err != nil:
+			return nil, renderResult.err
+		default:
+			chartID, err := uuid.NewRandom()
+			if err != nil {
+				return nil, ErrGenerateChartIDFailed
+			}
+
+			return convert.RenderChartReplyToAPIChartReply(opts.RequestID, chartID.String(), now, renderResult.reply), nil
+		}
+	}
+}
+
+type renderChartResult struct {
+	reply *render.RenderChartReply
+	err   error
+}
+
+func renderChart(ctx context.Context, client render.ChartRendererClient, req *render.RenderChartRequest) <-chan renderChartResult {
+	result := make(chan renderChartResult)
+
+	go func() {
+		reply, err := client.RenderChart(ctx, req)
+		result <- renderChartResult{reply, err}
+		close(result)
+	}()
+
+	return result
+}
+
+func isTimedOutErr(err error) bool {
+	if errors.Is(err, status.Error(codes.DeadlineExceeded, context.DeadlineExceeded.Error())) {
+		return true
+	}
+
+	if errors.Is(err, status.Error(codes.Canceled, context.Canceled.Error())) {
+		return true
+	}
+
+	return false
+}

--- a/internal/renderer/renderer_test.go
+++ b/internal/renderer/renderer_test.go
@@ -1,0 +1,44 @@
+package renderer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/limpidchart/lc-api/internal/config"
+	"github.com/limpidchart/lc-api/internal/testutils"
+)
+
+func TestNewConn(t *testing.T) {
+	chartRendererServer, err := testutils.NewTestingChartRendererServer(testutils.Opts{
+		ChartData: nil,
+		FailMsg:   "",
+		Latency:   time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unable to start testing lc-renderer server: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	go func() {
+		if serveErr := chartRendererServer.Serve(ctx); serveErr != nil {
+			t.Errorf("unable to start testing lc-renderer server: %s", serveErr)
+
+			return
+		}
+	}()
+
+	rendererCfg := config.RendererConfig{
+		Address:               chartRendererServer.Address(),
+		ConnTimeoutSeconds:    testutils.RendererConnTimeoutSecs,
+		RequestTimeoutSeconds: testutils.RendererRequestTimeoutSecs,
+	}
+
+	chartRendererConn, err := NewConn(context.Background(), rendererCfg)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, chartRendererConn)
+}

--- a/internal/servergrpc/request_id.go
+++ b/internal/servergrpc/request_id.go
@@ -2,6 +2,7 @@ package servergrpc
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
@@ -11,10 +12,17 @@ type ctxKey int
 
 const ctxRequestID ctxKey = iota
 
+// ErrGenerateRequestIDFailed contains error message about failed request ID generation.
+var ErrGenerateRequestIDFailed = errors.New("unable to generate a random UUID for chart ID")
+
 func requestIDInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		reqID := uuid.New().String()
-		newCtx := context.WithValue(ctx, ctxRequestID, reqID)
+		reqID, err := uuid.NewRandom()
+		if err != nil {
+			return nil, ErrGenerateRequestIDFailed
+		}
+
+		newCtx := context.WithValue(ctx, ctxRequestID, reqID.String())
 
 		return handler(newCtx, req)
 	}

--- a/internal/testutils/rendererserver.go
+++ b/internal/testutils/rendererserver.go
@@ -15,6 +15,14 @@ import (
 	"github.com/limpidchart/lc-api/internal/tcputils"
 )
 
+const (
+	// RendererConnTimeoutSecs represents connection timeout for testing renderer server.
+	RendererConnTimeoutSecs = 2
+
+	// RendererRequestTimeoutSecs represents rendering timeout for testing renderer server.
+	RendererRequestTimeoutSecs = 1
+)
+
 // ErrRequestCancelled contains error message about cancelled testing lc-renderer request.
 var ErrRequestCancelled = errors.New("request to testing lc-renderer is cancelled")
 


### PR DESCRIPTION
Log stack in in recover interceptor.

Move renderer logic into `renderer` package.

Cleanup `main` package.

Add renderer timeouts to testutils.