### PR TITLE
Add HTTP middlewares

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/limpidchart/lc-api
 go 1.16
 
 require (
+	github.com/go-chi/chi/v5 v5.0.3
 	github.com/google/uuid v1.1.2
 	github.com/rs/zerolog v1.23.0
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/go-chi/chi/v5 v5.0.3 h1:khYQBdPivkYG1s1TAzDQG1f6eX4kD2TItYVZexL5rS4=
+github.com/go-chi/chi/v5 v5.0.3/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/internal/serverhttp/v0/middleware/chart_id.go
+++ b/internal/serverhttp/v0/middleware/chart_id.go
@@ -1,0 +1,48 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/limpidchart/lc-api/internal/serverhttp/v0/view"
+)
+
+// RequireChartID checks that chart_id parameter can be used and stores it in the context.
+func RequireChartID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawChartID := chi.URLParam(r, view.ParamChartID)
+		chartID, err := validateUUID(rawChartID)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			MarshalJSON(w, view.NewError(fmt.Sprintf("%s value is bad: %s", view.ParamChartID, err)))
+
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), ctxChartID, chartID.String())
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// GetChartID retrieves chart_id value from context.
+func GetChartID(ctx context.Context) string {
+	if chartID, ok := ctx.Value(ctxChartID).(string); ok {
+		return chartID
+	}
+
+	return ""
+}
+
+func validateUUID(raw string) (uuid.UUID, error) {
+	u, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf(`unable to parse "%s" as UUID: %w`, raw, err)
+	}
+
+	return u, nil
+}

--- a/internal/serverhttp/v0/middleware/create_chart.go
+++ b/internal/serverhttp/v0/middleware/create_chart.go
@@ -1,0 +1,52 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/limpidchart/lc-api/internal/convert"
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/serverhttp/v0/view"
+)
+
+// RequireCreateChartParams checks if provided create chart parameters body can be used and stores it in the context.
+func RequireCreateChartParams() func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// nolint: exhaustivestruct
+			createOptsJSON := view.CreateChartRequest{}
+
+			err := json.NewDecoder(r.Body).Decode(&createOptsJSON)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				MarshalJSON(w, view.NewError("Create chart body is not a valid JSON"))
+
+				return
+			}
+
+			createChartRequest, err := convert.JSONToCreateChartRequest(&createOptsJSON)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				MarshalJSON(w, view.NewError(fmt.Sprintf("Unable to use the provided create chart parameters: %s", err)))
+
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), ctxCreateChartRequest, createChartRequest)
+
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// GetCreateChartRequest retrieves create chart request from context.
+func GetCreateChartRequest(ctx context.Context) *render.CreateChartRequest {
+	v, ok := ctx.Value(ctxCreateChartRequest).(*render.CreateChartRequest)
+	if !ok {
+		return nil
+	}
+
+	return v
+}

--- a/internal/serverhttp/v0/middleware/keys.go
+++ b/internal/serverhttp/v0/middleware/keys.go
@@ -1,0 +1,18 @@
+package middleware
+
+const (
+	// RequestIDLogKey represents a request ID key logger field.
+	RequestIDLogKey = "request_id"
+
+	// ChartIDLogKey represents a chart ID key logger field.
+	ChartIDLogKey = "chart_id"
+)
+
+// Context keys.
+type ctxKey int
+
+const (
+	ctxRequestID ctxKey = iota
+	ctxChartID
+	ctxCreateChartRequest
+)

--- a/internal/serverhttp/v0/middleware/logger.go
+++ b/internal/serverhttp/v0/middleware/logger.go
@@ -1,0 +1,108 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/rs/zerolog"
+)
+
+const (
+	xRealIPHeader       = "x-real-ip"
+	xForwardedForHeader = "x-forwarded-for"
+	userAgentHeader     = "user-agent"
+	refererHeader       = "referer"
+)
+
+const (
+	ipKey           = "ip"
+	userAgentKey    = "user_agent"
+	refererKey      = refererHeader
+	codeKey         = "code"
+	methodKey       = "method"
+	pathKey         = "path"
+	bytesWrittenKey = "resp_bytes_written"
+	durationKey     = "duration"
+)
+
+const (
+	errCodesStart  = 500
+	warnCodesStart = 400
+)
+
+// RequestLogger handles logging of additional information about every request.
+func RequestLogger(log *zerolog.Logger) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ww := chimiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
+			startTime := time.Now().UTC()
+
+			next.ServeHTTP(ww, r)
+
+			defer func() {
+				statusCode := ww.Status()
+				bytesWritten := ww.BytesWritten()
+
+				switch {
+				case statusCode >= errCodesStart:
+					logEvent := loggerFields(log.Error(), r, statusCode, bytesWritten, startTime)
+					logEvent.Msg("")
+				case statusCode >= warnCodesStart:
+					logEvent := loggerFields(log.Warn(), r, statusCode, bytesWritten, startTime)
+					logEvent.Msg("")
+				default:
+					logEvent := loggerFields(log.Info(), r, statusCode, bytesWritten, startTime)
+					logEvent.Msg("")
+				}
+			}()
+		})
+	}
+}
+
+func loggerFields(logEvent *zerolog.Event, r *http.Request, code, bytesWritten int, startTime time.Time) *zerolog.Event {
+	event := logEvent.
+		Time(zerolog.TimestampFieldName, startTime).
+		Str(RequestIDLogKey, GetRequestID(r.Context())).
+		Str(ipKey, peerIP(r)).
+		Str(userAgentKey, r.Header.Get(userAgentHeader)).
+		Str(refererKey, r.Header.Get(refererHeader)).
+		Int(codeKey, code).
+		Str(methodKey, r.Method).
+		Str(pathKey, r.URL.Path).
+		Int(bytesWrittenKey, bytesWritten).
+		Dur(durationKey, time.Since(startTime))
+
+	chartID := GetChartID(r.Context())
+	if chartID == "" {
+		return event
+	}
+
+	return event.Str(ChartIDLogKey, GetChartID(r.Context()))
+}
+
+func peerIP(r *http.Request) string {
+	realIP := r.Header.Get(xRealIPHeader)
+	forwardedFor := r.Header.Get(xForwardedForHeader)
+
+	if realIP == "" && forwardedFor == "" {
+		return ipFromRemoteAddr(r.RemoteAddr)
+	}
+
+	if forwardedFor == "" {
+		return realIP
+	}
+
+	return strings.Split(forwardedFor, ",")[0]
+}
+
+func ipFromRemoteAddr(s string) string {
+	idx := strings.LastIndex(s, ":")
+	if idx == -1 {
+		return s
+	}
+
+	return s[:idx]
+}

--- a/internal/serverhttp/v0/middleware/marshal_json.go
+++ b/internal/serverhttp/v0/middleware/marshal_json.go
@@ -1,0 +1,24 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+const (
+	contentTypeHeader = "Content-Type"
+	contentTypeJSON   = "application/json; charset=utf-8"
+)
+
+// MarshalJSON marshals 'v' to JSON, automatically escaping HTML and setting the Content-Type as application/json.
+// It will call http.Error in case of failures.
+func MarshalJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set(contentTypeHeader, contentTypeJSON)
+
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(true)
+
+	if err := enc.Encode(v); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+}

--- a/internal/serverhttp/v0/middleware/recover.go
+++ b/internal/serverhttp/v0/middleware/recover.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"net/http"
+	"runtime"
+
+	"github.com/rs/zerolog"
+)
+
+const stackSize = 8192
+
+// Recover catches panics and returns the Internal Server Error back to the caller.
+func Recover(log *zerolog.Logger) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					stack := make([]byte, stackSize)
+					stack = stack[:runtime.Stack(stack, false)]
+
+					log.Error().Bytes(zerolog.ErrorStackFieldName, stack).Interface(zerolog.ErrorFieldName, rec).Msg("HTTP server panicked")
+
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+
+					return
+				}
+			}()
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/serverhttp/v0/middleware/recover_test.go
+++ b/internal/serverhttp/v0/middleware/recover_test.go
@@ -1,0 +1,60 @@
+package middleware_test
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/limpidchart/lc-api/internal/serverhttp/v0/middleware"
+)
+
+// nolint: paralleltest
+func TestRecoverer(t *testing.T) {
+	logFile, err := ioutil.TempFile(os.TempDir(), "test_recovery.log")
+	if err != nil {
+		t.Fatalf("unable to create temp log file: %s", err)
+	}
+
+	defer os.Remove(logFile.Name())
+	defer logFile.Close()
+
+	logger := zerolog.New(logFile)
+	router := chi.NewRouter()
+	router.Use(middleware.Recover(&logger))
+	router.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		panic("some nil point reference or whatever")
+	})
+
+	w := httptest.NewRecorder()
+
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	if err != nil {
+		t.Fatalf("unable to make a test request: %s", err)
+	}
+
+	router.ServeHTTP(w, r)
+
+	expectedMessages := []string{
+		`"stack":"goroutine`,
+		`"error":"some nil point reference or whatever"`,
+		`"message":"HTTP server panicked"`,
+	}
+
+	contents, err := ioutil.ReadFile(logFile.Name())
+	if err != nil {
+		t.Logf("unable to read temp log file: %s", err)
+	}
+
+	for _, expectedMsg := range expectedMessages {
+		msgInLog := strings.Contains(string(contents), expectedMsg)
+		assert.True(t, msgInLog)
+	}
+}

--- a/internal/serverhttp/v0/middleware/request_id.go
+++ b/internal/serverhttp/v0/middleware/request_id.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// SetRequestID request ID and saves it into the context.
+func SetRequestID(log *zerolog.Logger) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			reqID, err := uuid.NewRandom()
+			if err != nil {
+				log.Error().Err(err).Msg("unable to generate a random UUID for request ID")
+
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), ctxRequestID, reqID.String())
+
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// GetRequestID returns request ID or empty string if it's not set.
+func GetRequestID(ctx context.Context) string {
+	if reqID, ok := ctx.Value(ctxRequestID).(string); ok {
+		return reqID
+	}
+
+	return ""
+}

--- a/internal/serverhttp/v0/view/param.go
+++ b/internal/serverhttp/v0/view/param.go
@@ -1,0 +1,14 @@
+package view
+
+const ParamChartID = "chart_id"
+
+// ChartID represents chart ID from URL.
+//
+// swagger:parameters getChart
+type ChartID struct {
+	// Chart identifier.
+	//
+	// in: path
+	// type: string
+	ChartID string `json:"chart_id"`
+}


### PR DESCRIPTION
Add basic middlewares to retrieve data from request, log requests, catch
panics and to generate random request ID.

Add `chart_id` parameter to view package.