### PR TITLE
Add /v0/charts routes

### DIFF
--- a/internal/serverhttp/chartapiserver.go
+++ b/internal/serverhttp/chartapiserver.go
@@ -1,0 +1,9 @@
+package serverhttp
+
+const (
+	// GroupV0 represents routing group pattern of the v0 API version.
+	GroupV0 = "/v0"
+
+	// GroupCharts represents routing group pattern of the charts API.
+	GroupCharts = "/charts"
+)

--- a/internal/serverhttp/v0/resource/chart/routes.go
+++ b/internal/serverhttp/v0/resource/chart/routes.go
@@ -1,0 +1,137 @@
+package chart
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog"
+
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/renderer"
+	"github.com/limpidchart/lc-api/internal/serverhttp/v0/middleware"
+	"github.com/limpidchart/lc-api/internal/serverhttp/v0/view"
+)
+
+// Routes implements HTTP handler for charts requests.
+func Routes(log *zerolog.Logger, rendererClient render.ChartRendererClient, rendererReqTimeout time.Duration) http.Handler {
+	r := chi.NewRouter().
+		With(middleware.Recover(log)).
+		With(middleware.SetRequestID(log)).
+		With(middleware.RequestLogger(log))
+
+	// swagger:route POST /charts Charts createChart
+	//
+	// Create a new chart
+	//
+	// Schemes: http, https
+	//
+	// Produces:
+	//   - application/json
+	//
+	// Responses:
+	//   default: error
+	//   201: chartRepr
+	r.
+		With(middleware.RequireCreateChartParams()).
+		Post("/", createChartHandler(log, rendererClient, rendererReqTimeout))
+
+	// swagger:route GET /charts/{chart_id} Charts getChart
+	//
+	// Get chart by ID
+	//
+	// Schemes: http, https
+	//
+	// Produces:
+	//   - application/json
+	//
+	// Responses:
+	//   default: error
+	//   200: chartRepr
+	//   404: notFoundError
+	r.
+		With(middleware.RequireChartID).
+		Get(fmt.Sprintf("/{%s}", view.ParamChartID), getChartHandler(log))
+
+	// swagger:route GET /charts Charts listCharts
+	//
+	// Get charts list
+	//
+	// Schemes: http, https
+	//
+	// Produces:
+	//   - application/json
+	//
+	// Responses:
+	//   default: error
+	r.Get("/", listChartsHandler())
+
+	return r
+}
+
+func createChartHandler(log *zerolog.Logger, rendererClient render.ChartRendererClient, rendererReqTimeout time.Duration) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		reqID := middleware.GetRequestID(r.Context())
+		log := log.With().Str(middleware.RequestIDLogKey, reqID).Logger()
+
+		createChartRequest := middleware.GetCreateChartRequest(r.Context())
+		if createChartRequest == nil {
+			log.Error().Msg("create chart request is empty after middlewares validation")
+
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+
+			return
+		}
+
+		res, err := renderer.CreateChart(r.Context(), renderer.CreateChartOpts{
+			RequestID:      reqID,
+			Request:        createChartRequest,
+			RendererClient: rendererClient,
+			Timeout:        rendererReqTimeout,
+		})
+
+		switch {
+		case err == nil:
+			w.WriteHeader(http.StatusCreated)
+			middleware.MarshalJSON(w, NewCreatedChartFromReply(res))
+		case errors.Is(err, renderer.ErrGenerateChartIDFailed):
+			log.Error().Err(err).Msg(fmt.Sprintf("unable to generate a random UUID for %s", view.ParamChartID))
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		case errors.Is(err, renderer.ErrCreateChartRequestCancelled):
+			log.Warn().Msg("renderer request timed-out")
+			http.Error(w, http.StatusText(http.StatusRequestTimeout), http.StatusRequestTimeout)
+		default:
+			log.Warn().Err(err).Msg("unable to render a chart")
+			http.Error(w, fmt.Sprintf("unable to render a chart: %s", err.Error()), http.StatusBadRequest)
+		}
+	}
+}
+
+func getChartHandler(log *zerolog.Logger) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		reqID := middleware.GetRequestID(r.Context())
+		log := log.With().Str(middleware.RequestIDLogKey, reqID).Logger()
+
+		chartID := middleware.GetChartID(r.Context())
+		if chartID == "" {
+			log.Error().Msg("unable to get chart_id from context")
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+
+			return
+		}
+
+		// We return 404 until storage backend is implemented.
+		w.WriteHeader(http.StatusNotFound)
+		middleware.MarshalJSON(w, view.NewNotFoundError("chart", chartID))
+	}
+}
+
+func listChartsHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// We return error until auth is implemented.
+		w.WriteHeader(http.StatusNotImplemented)
+		middleware.MarshalJSON(w, view.NewError("Unable to get list of charts since auth is not implemented yet"))
+	}
+}

--- a/internal/serverhttp/v0/resource/chart/routes_create_chart_test.go
+++ b/internal/serverhttp/v0/resource/chart/routes_create_chart_test.go
@@ -1,0 +1,272 @@
+package chart_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/limpidchart/lc-api/internal/config"
+	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
+	"github.com/limpidchart/lc-api/internal/renderer"
+	"github.com/limpidchart/lc-api/internal/serverhttp"
+	"github.com/limpidchart/lc-api/internal/serverhttp/v0/resource/chart"
+	"github.com/limpidchart/lc-api/internal/serverhttp/v0/view"
+	"github.com/limpidchart/lc-api/internal/testutils"
+)
+
+const testingRendererEnvTimeoutSecs = 5
+
+type testingRendererEnv struct {
+	rendererClient render.ChartRendererClient
+}
+
+type testingRendererEnvOpts struct {
+	rendererFailMsg   string
+	rendererChartData []byte
+	rendererLatency   time.Duration
+}
+
+func newTestingRendererEnv(ctx context.Context, t *testing.T, opts testingRendererEnvOpts) (*testingRendererEnv, error) {
+	t.Helper()
+
+	chartRendererServer, err := testutils.NewTestingChartRendererServer(testutils.Opts{
+		ChartData: opts.rendererChartData,
+		FailMsg:   opts.rendererFailMsg,
+		Latency:   opts.rendererLatency,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to configure testing lc-renderer server: %w", err)
+	}
+
+	go func() {
+		if serveErr := chartRendererServer.Serve(ctx); serveErr != nil {
+			t.Errorf("unable to start testing lc-renderer server: %s", serveErr)
+
+			return
+		}
+	}()
+
+	// nolint: exhaustivestruct
+	cfg := config.Config{
+		Renderer: config.RendererConfig{
+			Address:               chartRendererServer.Address(),
+			ConnTimeoutSeconds:    testutils.RendererConnTimeoutSecs,
+			RequestTimeoutSeconds: testutils.RendererRequestTimeoutSecs,
+		},
+	}
+
+	rendererConn, err := renderer.NewConn(context.Background(), cfg.Renderer)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create a connection to testing lc-renderer: %w", err)
+	}
+
+	return &testingRendererEnv{render.NewChartRendererClient(rendererConn)}, nil
+}
+
+func verticalAndLineChartRequest(t *testing.T) []byte {
+	t.Helper()
+
+	reqBody := testutils.NewJSONCreateChartRequest().
+		SetTitle().
+		SetSizes().
+		SetMargins().
+		SetBandBottomAxis().
+		SetLinearLeftAxis().
+		AddVerticalBarView().
+		AddLineView().
+		Unembed()
+
+	reqBodyJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("unable to marshal request body: %s", err)
+	}
+
+	return reqBodyJSON
+}
+
+func noAxesChartRequest(t *testing.T) []byte {
+	t.Helper()
+
+	reqBody := testutils.NewJSONCreateChartRequest().
+		SetTitle().
+		SetSizes().
+		SetMargins().
+		AddVerticalBarView().
+		AddLineView().
+		Unembed()
+
+	reqBodyJSON, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatalf("unable to marshal request body: %s", err)
+	}
+
+	return reqBodyJSON
+}
+
+func TestCreateChart_VerticalAndLineOK(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*testingRendererEnvTimeoutSecs)
+	defer cancel()
+
+	chartData := []byte(`<svg>vertical_and_line</svg>`)
+
+	testingRendererEnv, err := newTestingRendererEnv(ctx, t, testingRendererEnvOpts{
+		rendererChartData: chartData,
+		rendererFailMsg:   "",
+		rendererLatency:   time.Millisecond * 100,
+	})
+	if err != nil {
+		t.Fatalf("unable to start testing renderer environment: %s", err)
+	}
+
+	log := zerolog.New(os.Stderr)
+	router := chi.NewRouter()
+	router.Route(serverhttp.GroupV0, func(router chi.Router) {
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, testingRendererEnv.rendererClient, time.Second*time.Duration(testutils.RendererRequestTimeoutSecs)))
+	})
+
+	w := httptest.NewRecorder()
+	url := strings.Join([]string{serverhttp.GroupV0, serverhttp.GroupCharts}, "")
+
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(verticalAndLineChartRequest(t)))
+	if err != nil {
+		t.Fatalf("unable to prepare HTTP request: %s", err)
+	}
+
+	router.ServeHTTP(w, r)
+
+	resp := w.Result()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unable to read response body: %s", err)
+	}
+
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	type respChart struct {
+		Chart *view.ChartReply `json:"chart"`
+	}
+
+	// nolint: exhaustivestruct
+	respBody := respChart{}
+
+	if err = json.Unmarshal(body, &respBody); err != nil {
+		t.Fatalf("unable to unmarshal the response body: %s", err)
+	}
+
+	assert.NotEmpty(t, respBody.Chart.RequestID)
+	assert.NotEmpty(t, respBody.Chart.ChartID)
+	assert.NotEmpty(t, respBody.Chart.CreatedAt)
+	assert.NotEmpty(t, respBody.Chart.DeletedAt)
+	assert.Equal(t, respBody.Chart.CreatedAt, respBody.Chart.DeletedAt) // equal until the storage backend is implemented
+	assert.Equal(t, view.ChartStatusCreated.String(), respBody.Chart.ChartStatus)
+	assert.Equal(t, string(chartData), respBody.Chart.ChartData)
+}
+
+func TestCreateChart_ErrTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*testingRendererEnvTimeoutSecs)
+	defer cancel()
+
+	chartData := []byte("wont_happen")
+
+	testingRendererEnv, err := newTestingRendererEnv(ctx, t, testingRendererEnvOpts{
+		rendererChartData: chartData,
+		rendererFailMsg:   "",
+		rendererLatency:   time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("unable to start testing renderer environment: %s", err)
+	}
+
+	log := zerolog.New(os.Stderr)
+	router := chi.NewRouter()
+	router.Route(serverhttp.GroupV0, func(router chi.Router) {
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, testingRendererEnv.rendererClient, time.Second*time.Duration(testutils.RendererRequestTimeoutSecs)))
+	})
+
+	w := httptest.NewRecorder()
+	url := strings.Join([]string{serverhttp.GroupV0, serverhttp.GroupCharts}, "")
+
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(verticalAndLineChartRequest(t)))
+	if err != nil {
+		t.Fatalf("unable to prepare HTTP request: %s", err)
+	}
+
+	router.ServeHTTP(w, r)
+
+	resp := w.Result()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unable to read response body: %s", err)
+	}
+
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusRequestTimeout, resp.StatusCode)
+	assert.Equal(t, http.StatusText(http.StatusRequestTimeout)+"\n", string(body))
+}
+
+func TestCreateChart_ErrNoAxes(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*testingRendererEnvTimeoutSecs)
+	defer cancel()
+
+	chartData := []byte("bad_axes")
+
+	testingRendererEnv, err := newTestingRendererEnv(ctx, t, testingRendererEnvOpts{
+		rendererChartData: chartData,
+		rendererFailMsg:   "",
+		rendererLatency:   time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("unable to start testing renderer environment: %s", err)
+	}
+
+	log := zerolog.New(os.Stderr)
+	router := chi.NewRouter()
+	router.Route(serverhttp.GroupV0, func(router chi.Router) {
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, testingRendererEnv.rendererClient, time.Second*time.Duration(testutils.RendererRequestTimeoutSecs)))
+	})
+
+	w := httptest.NewRecorder()
+	url := strings.Join([]string{serverhttp.GroupV0, serverhttp.GroupCharts}, "")
+
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(noAxesChartRequest(t)))
+	if err != nil {
+		t.Fatalf("unable to prepare HTTP request: %s", err)
+	}
+
+	router.ServeHTTP(w, r)
+
+	resp := w.Result()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unable to read response body: %s", err)
+	}
+
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "unable to render a chart: unable to validate chart axes: chart axes are not specified\n", string(body))
+}

--- a/internal/serverhttp/v0/resource/chart/routes_get_chart_test.go
+++ b/internal/serverhttp/v0/resource/chart/routes_get_chart_test.go
@@ -1,0 +1,85 @@
+package chart_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/limpidchart/lc-api/internal/serverhttp"
+	"github.com/limpidchart/lc-api/internal/serverhttp/v0/resource/chart"
+	"github.com/limpidchart/lc-api/internal/serverhttp/v0/view"
+	"github.com/limpidchart/lc-api/internal/testutils"
+)
+
+func TestGetChart_NotFound(t *testing.T) {
+	t.Parallel()
+
+	log := zerolog.New(os.Stderr)
+	router := chi.NewRouter()
+	router.Route(serverhttp.GroupV0, func(router chi.Router) {
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, nil, 0))
+	})
+
+	w := httptest.NewRecorder()
+	chartID := testutils.RandomUUID(t).String()
+	url := fmt.Sprintf("%s%s/%s", serverhttp.GroupV0, serverhttp.GroupCharts, chartID)
+
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("unable to prepare HTTP request: %s", err)
+	}
+
+	router.ServeHTTP(w, r)
+
+	resp := w.Result()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unable to read response body: %s", err)
+	}
+
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, testutils.EncodeToJSON(t, view.NewNotFoundError("chart", chartID)), string(body))
+}
+
+func TestGetChart_BadChartID(t *testing.T) {
+	t.Parallel()
+
+	log := zerolog.New(os.Stderr)
+	router := chi.NewRouter()
+	router.Route(serverhttp.GroupV0, func(router chi.Router) {
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, nil, 0))
+	})
+
+	w := httptest.NewRecorder()
+	url := fmt.Sprintf("%s%s/%s", serverhttp.GroupV0, serverhttp.GroupCharts, "mychart")
+
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("unable to prepare HTTP request: %s", err)
+	}
+
+	router.ServeHTTP(w, r)
+
+	resp := w.Result()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unable to read response body: %s", err)
+	}
+
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, testutils.EncodeToJSON(t, view.NewError(`chart_id value is bad: unable to parse "mychart" as UUID: invalid UUID length: 7`)), string(body))
+}

--- a/internal/serverhttp/v0/resource/chart/routes_list_charts_test.go
+++ b/internal/serverhttp/v0/resource/chart/routes_list_charts_test.go
@@ -1,0 +1,52 @@
+package chart_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/limpidchart/lc-api/internal/serverhttp"
+	"github.com/limpidchart/lc-api/internal/serverhttp/v0/resource/chart"
+	"github.com/limpidchart/lc-api/internal/serverhttp/v0/view"
+	"github.com/limpidchart/lc-api/internal/testutils"
+)
+
+func TestListCharts_Unimplemented(t *testing.T) {
+	t.Parallel()
+
+	log := zerolog.New(os.Stderr)
+	router := chi.NewRouter()
+	router.Route(serverhttp.GroupV0, func(router chi.Router) {
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, nil, 0))
+	})
+
+	w := httptest.NewRecorder()
+	url := strings.Join([]string{serverhttp.GroupV0, serverhttp.GroupCharts}, "")
+
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("unable to prepare HTTP request: %s", err)
+	}
+
+	router.ServeHTTP(w, r)
+
+	resp := w.Result()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unable to read response body: %s", err)
+	}
+
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+	assert.Equal(t, testutils.EncodeToJSON(t, view.NewError("Unable to get list of charts since auth is not implemented yet")), string(body))
+}

--- a/internal/testutils/jsonresp.go
+++ b/internal/testutils/jsonresp.go
@@ -1,0 +1,22 @@
+package testutils
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// EncodeToJSON encodes the provided `v` into JSON string.
+func EncodeToJSON(t *testing.T, v interface{}) string {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(true)
+
+	if err := enc.Encode(v); err != nil {
+		t.Fatalf("unable to endode JSON: %s", err)
+	}
+
+	return buf.String()
+}

--- a/internal/testutils/random.go
+++ b/internal/testutils/random.go
@@ -2,7 +2,10 @@ package testutils
 
 import (
 	"math/rand"
+	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -17,4 +20,15 @@ func RandomString(size int) string {
 	}
 
 	return string(res)
+}
+
+func RandomUUID(t *testing.T) uuid.UUID {
+	t.Helper()
+
+	u, err := uuid.NewRandom()
+	if err != nil {
+		t.Fatalf("unable to generate random UUID: %s", err)
+	}
+
+	return u
 }


### PR DESCRIPTION
Add routes to create, get, list charts with unit tests.

Add testutils to generate random UUIDs and to marshal interfaces to JSON
strings.