### PR TITLE
Shroten axis, margins JSON fields

### DIFF
--- a/internal/convert/jsontoapi.go
+++ b/internal/convert/jsontoapi.go
@@ -75,20 +75,20 @@ func chartMarginsFromJSON(margins *view.ChartMargins) *render.ChartMargins {
 		marginRight  *wrapperspb.Int32Value
 	)
 
-	if margins.MarginTop != nil {
-		marginTop = &wrapperspb.Int32Value{Value: int32(*margins.MarginTop)}
+	if margins.Top != nil {
+		marginTop = &wrapperspb.Int32Value{Value: int32(*margins.Top)}
 	}
 
-	if margins.MarginBottom != nil {
-		marginBottom = &wrapperspb.Int32Value{Value: int32(*margins.MarginBottom)}
+	if margins.Bottom != nil {
+		marginBottom = &wrapperspb.Int32Value{Value: int32(*margins.Bottom)}
 	}
 
-	if margins.MarginLeft != nil {
-		marginLeft = &wrapperspb.Int32Value{Value: int32(*margins.MarginLeft)}
+	if margins.Left != nil {
+		marginLeft = &wrapperspb.Int32Value{Value: int32(*margins.Left)}
 	}
 
-	if margins.MarginRight != nil {
-		marginRight = &wrapperspb.Int32Value{Value: int32(*margins.MarginRight)}
+	if margins.Right != nil {
+		marginRight = &wrapperspb.Int32Value{Value: int32(*margins.Right)}
 	}
 
 	return &render.ChartMargins{
@@ -104,35 +104,35 @@ func chartAxesFromJSON(axes *view.ChartAxes) (*render.ChartAxes, error) {
 		return nil, nil
 	}
 
-	axisTop, err := jsontoapi.ChartScaleFromJSON(axes.AxisTop)
+	axisTop, err := jsontoapi.ChartScaleFromJSON(axes.Top)
 	if err != nil {
 		return nil, fmt.Errorf("unable to validate top chart scale: %w", err)
 	}
 
-	axisBottom, err := jsontoapi.ChartScaleFromJSON(axes.AxisBottom)
+	axisBottom, err := jsontoapi.ChartScaleFromJSON(axes.Bottom)
 	if err != nil {
 		return nil, fmt.Errorf("unable to validate bottom chart scale: %w", err)
 	}
 
-	axisLeft, err := jsontoapi.ChartScaleFromJSON(axes.AxisLeft)
+	axisLeft, err := jsontoapi.ChartScaleFromJSON(axes.Left)
 	if err != nil {
 		return nil, fmt.Errorf("unable to validate left chart scale: %w", err)
 	}
 
-	axisRight, err := jsontoapi.ChartScaleFromJSON(axes.AxisRight)
+	axisRight, err := jsontoapi.ChartScaleFromJSON(axes.Right)
 	if err != nil {
 		return nil, fmt.Errorf("unable to validate right chart scale: %w", err)
 	}
 
 	return &render.ChartAxes{
 		AxisTop:         axisTop,
-		AxisTopLabel:    axes.AxisTopLabel,
+		AxisTopLabel:    axes.TopLabel,
 		AxisBottom:      axisBottom,
-		AxisBottomLabel: axes.AxisBottomLabel,
+		AxisBottomLabel: axes.BottomLabel,
 		AxisLeft:        axisLeft,
-		AxisLeftLabel:   axes.AxisLeftLabel,
+		AxisLeftLabel:   axes.LeftLabel,
 		AxisRight:       axisRight,
-		AxisRightLabel:  axes.AxisRightLabel,
+		AxisRightLabel:  axes.RightLabel,
 	}, nil
 }
 

--- a/internal/serverhttp/v0/view/chart.go
+++ b/internal/serverhttp/v0/view/chart.go
@@ -11,42 +11,42 @@ type ChartSizes struct {
 
 // ChartMargins represents options to configure chart margins.
 type ChartMargins struct {
-	// MarginTop represents chart top margin.
-	MarginTop *int `json:"margin_top,omitempty"`
+	// Top represents chart top margin.
+	Top *int `json:"top,omitempty"`
 
-	// MarginBottom represents chart bottom margin.
-	MarginBottom *int `json:"margin_bottom,omitempty"`
+	// Bottom represents chart bottom margin.
+	Bottom *int `json:"bottom,omitempty"`
 
-	// MarginLeft represents chart left margin.
-	MarginLeft *int `json:"margin_left,omitempty"`
+	// Left represents chart left margin.
+	Left *int `json:"left,omitempty"`
 
-	// MarginRight represents chart right margin.
-	MarginRight *int `json:"margin_right,omitempty"`
+	// Right represents chart right margin.
+	Right *int `json:"right,omitempty"`
 }
 
 // ChartAxes represents options to configure chart axes.
 type ChartAxes struct {
-	// AxisTop represents configured scale for top axis.
-	AxisTop *ChartScale `json:"axis_top,omitempty"`
+	// Top represents configured scale for top axis.
+	Top *ChartScale `json:"top,omitempty"`
 
-	// AxisTopLabel represents label for top axis.
-	AxisTopLabel string `json:"axis_top_label,omitempty"`
+	// TopLabel represents label for top axis.
+	TopLabel string `json:"top_label,omitempty"`
 
-	// AxisBottom represents configured scale for botom axis.
-	AxisBottom *ChartScale `json:"axis_bottom,omitempty"`
+	// Bottom represents configured scale for botom axis.
+	Bottom *ChartScale `json:"bottom,omitempty"`
 
-	// AxisBottomLabel represents label for bottom axis.
-	AxisBottomLabel string `json:"axis_bottom_label,omitempty"`
+	// BottomLabel represents label for bottom axis.
+	BottomLabel string `json:"bottom_label,omitempty"`
 
-	// AxisLeft represents configured scale for left axis.
-	AxisLeft *ChartScale `json:"axis_left,omitempty"`
+	// Left represents configured scale for left axis.
+	Left *ChartScale `json:"left,omitempty"`
 
-	// AxisLeftLabel represents label for left axis.
-	AxisLeftLabel string `json:"axis_left_label,omitempty"`
+	// LeftLabel represents label for left axis.
+	LeftLabel string `json:"left_label,omitempty"`
 
-	// AxisRight represents configured scale for right axis.
-	AxisRight *ChartScale `json:"axis_right,omitempty"`
+	// Right represents configured scale for right axis.
+	Right *ChartScale `json:"right,omitempty"`
 
-	// AxisRightLabel represents label for right axis.
-	AxisRightLabel string `json:"axis_right_label,omitempty"`
+	// RightLabel represents label for right axis.
+	RightLabel string `json:"right_label,omitempty"`
 }

--- a/internal/testutils/jsonchartrequests.go
+++ b/internal/testutils/jsonchartrequests.go
@@ -34,10 +34,10 @@ func (req *JSONCreateChartRequest) SetSizes() *JSONCreateChartRequest {
 func (req *JSONCreateChartRequest) SetMargins() *JSONCreateChartRequest {
 	// nolint: gomnd
 	req.Chart.Margins = &view.ChartMargins{
-		MarginTop:    intToPtr(10),
-		MarginBottom: intToPtr(20),
-		MarginLeft:   intToPtr(30),
-		MarginRight:  intToPtr(40),
+		Top:    intToPtr(10),
+		Bottom: intToPtr(20),
+		Left:   intToPtr(30),
+		Right:  intToPtr(40),
 	}
 
 	return req
@@ -50,7 +50,7 @@ func (req *JSONCreateChartRequest) SetBandBottomAxis() *JSONCreateChartRequest {
 		axes = &view.ChartAxes{}
 	}
 
-	axes.AxisBottom = NewJSONBandChartScale().Unembed()
+	axes.Bottom = NewJSONBandChartScale().Unembed()
 	req.Chart.Axes = axes
 
 	return req
@@ -63,7 +63,7 @@ func (req *JSONCreateChartRequest) SetBottomAxisLabel() *JSONCreateChartRequest 
 		axes = &view.ChartAxes{}
 	}
 
-	axes.AxisBottomLabel = "Bottom Axis"
+	axes.BottomLabel = "Bottom Axis"
 	req.Chart.Axes = axes
 
 	return req
@@ -76,7 +76,7 @@ func (req *JSONCreateChartRequest) SetLinearLeftAxis() *JSONCreateChartRequest {
 		axes = &view.ChartAxes{}
 	}
 
-	axes.AxisLeft = NewJSONLinearChartScale().Unembed()
+	axes.Left = NewJSONLinearChartScale().Unembed()
 	req.Chart.Axes = axes
 
 	return req
@@ -89,7 +89,7 @@ func (req *JSONCreateChartRequest) SetLeftAxisLabel() *JSONCreateChartRequest {
 		axes = &view.ChartAxes{}
 	}
 
-	axes.AxisLeftLabel = "Left Axis"
+	axes.LeftLabel = "Left Axis"
 	req.Chart.Axes = axes
 
 	return req


### PR DESCRIPTION
Remove "Axis*" and "Margin*" prefix from JSON fields since they already
nested in "Axes" and "Margins" structures.