### PR TITLE
Add compress middleware and fix content reponse

### DIFF
--- a/internal/serverhttp/v0/middleware/backend_check.go
+++ b/internal/serverhttp/v0/middleware/backend_check.go
@@ -16,8 +16,7 @@ func BackendCheck(log *zerolog.Logger, b backend.Backend) func(next http.Handler
 			if !b.IsHealthy() {
 				log.Error().Msg("Backend connections are not healthy")
 
-				w.WriteHeader(http.StatusServiceUnavailable)
-				MarshalJSON(w, view.NewError(http.StatusText(http.StatusServiceUnavailable)))
+				MarshalJSON(w, http.StatusServiceUnavailable, view.NewError(http.StatusText(http.StatusServiceUnavailable)))
 
 				return
 			}

--- a/internal/serverhttp/v0/middleware/chart_id.go
+++ b/internal/serverhttp/v0/middleware/chart_id.go
@@ -24,8 +24,7 @@ func RequireChartID(log *zerolog.Logger) func(next http.Handler) http.Handler {
 
 				log.Warn().Msg(msg)
 
-				w.WriteHeader(http.StatusBadRequest)
-				MarshalJSON(w, view.NewError(msg))
+				MarshalJSON(w, http.StatusBadRequest, view.NewError(msg))
 
 				return
 			}

--- a/internal/serverhttp/v0/middleware/create_chart.go
+++ b/internal/serverhttp/v0/middleware/create_chart.go
@@ -27,16 +27,14 @@ func RequireCreateChartParams(log *zerolog.Logger) func(next http.Handler) http.
 
 				log.Warn().Msg(msg)
 
-				w.WriteHeader(http.StatusBadRequest)
-				MarshalJSON(w, view.NewError(msg))
+				MarshalJSON(w, http.StatusBadRequest, view.NewError(msg))
 
 				return
 			}
 
 			createChartRequest, err := convert.JSONToCreateChartRequest(&createOptsJSON)
 			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				MarshalJSON(w, view.NewError(fmt.Sprintf("Unable to use the provided create chart parameters: %s", err)))
+				MarshalJSON(w, http.StatusBadRequest, view.NewError(fmt.Sprintf("Unable to use the provided create chart parameters: %s", err)))
 
 				return
 			}

--- a/internal/serverhttp/v0/middleware/marshal_json.go
+++ b/internal/serverhttp/v0/middleware/marshal_json.go
@@ -7,13 +7,15 @@ import (
 
 const (
 	contentTypeHeader = "Content-Type"
-	contentTypeJSON   = "application/json; charset=utf-8"
+	jsonContentType   = "application/json"
 )
 
-// MarshalJSON marshals 'v' to JSON, automatically escaping HTML and setting the Content-Type as application/json.
-// It will call http.Error in case of failures.
-func MarshalJSON(w http.ResponseWriter, v interface{}) {
-	w.Header().Set(contentTypeHeader, contentTypeJSON)
+// MarshalJSON marshals 'v' to JSON, automatically escaping HTML, setting the Content-Type as application/json
+// and writing headers with the provided status code.
+// It calls http.Error in case of failures.
+func MarshalJSON(w http.ResponseWriter, statusCode int, v interface{}) {
+	w.Header().Set(contentTypeHeader, jsonContentType)
+	w.WriteHeader(statusCode)
 
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(true)

--- a/internal/serverhttp/v0/resource/chart/routes_get_chart_test.go
+++ b/internal/serverhttp/v0/resource/chart/routes_get_chart_test.go
@@ -48,6 +48,7 @@ func TestGetChart_NotFound(t *testing.T) {
 	resp.Body.Close()
 
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 	assert.Equal(t, fmt.Sprintf(`{"error":{"id":"%s","message":"chart not found"}}`+"\n", chartID), string(body))
 }
 
@@ -80,5 +81,6 @@ func TestGetChart_BadChartID(t *testing.T) {
 	resp.Body.Close()
 
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 	assert.Equal(t, `{"error":{"message":"chart_id value is bad: unable to parse mychart as UUID: invalid UUID length: 7"}}`+"\n", string(body))
 }

--- a/internal/serverhttp/v0/resource/chart/routes_list_charts_test.go
+++ b/internal/serverhttp/v0/resource/chart/routes_list_charts_test.go
@@ -47,5 +47,6 @@ func TestListCharts_Unimplemented(t *testing.T) {
 	resp.Body.Close()
 
 	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 	assert.Equal(t, `{"error":{"message":"List of charts handler is not implemented yet"}}`+"\n", string(body))
 }


### PR DESCRIPTION
Fix writing headers early so content-type response is default instead
of json.

Use chi compress middleware.

Compress "application/json" responses in case of "Accept-Encoding"
request header is set to "gzip" or "deflate".

Add test of making a request with gzip encoding.