### PR TITLE
Refactor backend, metric interfaces

### DIFF
--- a/internal/backend/empty.go
+++ b/internal/backend/empty.go
@@ -1,9 +1,8 @@
-package testutils
+package backend
 
 import (
 	"time"
 
-	"github.com/limpidchart/lc-api/internal/backend"
 	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
 )
 
@@ -12,8 +11,8 @@ type EmptyBackend struct {
 	healthy bool
 }
 
-// NewEmptyBackend returns a new TestingBackend.
-func NewEmptyBackend(healthy bool) backend.Backend {
+// NewEmptyBackend returns a new EmptyBackend.
+func NewEmptyBackend(healthy bool) *EmptyBackend {
 	return &EmptyBackend{healthy}
 }
 

--- a/internal/metric/empty.go
+++ b/internal/metric/empty.go
@@ -1,22 +1,20 @@
-package testutils
+package metric
 
 import (
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	"github.com/limpidchart/lc-api/internal/metric"
 )
 
-// EmptyRecorder represents testing metric recorder.
+// EmptyRecorder represents recorder without registered metrics.
 type EmptyRecorder struct {
 	requestDuration *prometheus.HistogramVec
 }
 
 // NewEmptyRecorder returns a new EmptyRecorder.
-func NewEmptyRecorder() metric.Recorder {
-	return &EmptyRecorder{metric.NewRequestDuration()}
+func NewEmptyRecorder() *EmptyRecorder {
+	return &EmptyRecorder{NewRequestDuration()}
 }
 
 // RequestDuration returns unregistered request_duration_seconds metric.

--- a/internal/metric/recorder.go
+++ b/internal/metric/recorder.go
@@ -27,13 +27,15 @@ const (
 	requestDurMetricHelp = "The latency of requests (seconds)."
 )
 
-// Recorder represents application metrics recorder.
-type Recorder interface {
+// PromRecorder represents an entity that records metrics and contains
+// configured HTTP handler that can be used by Prometheus.
+type PromRecorder interface {
 	RequestDuration() *prometheus.HistogramVec
 	HTTPHandler() http.Handler
 }
 
-type appRecorder struct {
+// Recorder represents application metrics recorder.
+type Recorder struct {
 	requestDuration *prometheus.HistogramVec
 	registerer      prometheus.Registerer
 	httpHandler     http.Handler
@@ -41,7 +43,7 @@ type appRecorder struct {
 
 // NewRecorder registers all metrics and returns a new metric recorder.
 // nolint: exhaustivestruct
-func NewRecorder() (Recorder, error) {
+func NewRecorder() (*Recorder, error) {
 	registry := prometheus.NewRegistry()
 
 	// Register basic collectors.
@@ -65,16 +67,16 @@ func NewRecorder() (Recorder, error) {
 		registry, promhttp.HandlerFor(registry, promhttp.HandlerOpts{}),
 	)
 
-	return &appRecorder{requestDuration, registry, httpHandler}, nil
+	return &Recorder{requestDuration, registry, httpHandler}, nil
 }
 
 // RequestDuration returns registered request_duration_seconds metric.
-func (r *appRecorder) RequestDuration() *prometheus.HistogramVec {
+func (r *Recorder) RequestDuration() *prometheus.HistogramVec {
 	return r.requestDuration
 }
 
 // HTTPHandler returns configured HTTP handler.
-func (r *appRecorder) HTTPHandler() http.Handler {
+func (r *Recorder) HTTPHandler() http.Handler {
 	return r.httpHandler
 }
 

--- a/internal/metric/server.go
+++ b/internal/metric/server.go
@@ -23,7 +23,7 @@ type Server struct {
 }
 
 // NewServer configures a new Server.
-func NewServer(log *zerolog.Logger, metricCfg config.MetricsConfig, mrec Recorder) (*Server, error) {
+func NewServer(log *zerolog.Logger, metricCfg config.MetricsConfig, pRec PromRecorder) (*Server, error) {
 	return &Server{
 		// nolint: exhaustivestruct
 		httpServer: &http.Server{
@@ -31,7 +31,7 @@ func NewServer(log *zerolog.Logger, metricCfg config.MetricsConfig, mrec Recorde
 			ReadTimeout:  time.Duration(metricCfg.ReadTimeoutSeconds) * time.Second,
 			WriteTimeout: time.Duration(metricCfg.WriteTimeoutSeconds) * time.Second,
 			IdleTimeout:  time.Duration(metricCfg.IdleTimeoutSeconds) * time.Second,
-			Handler:      routes(mrec),
+			Handler:      routes(pRec),
 		},
 		log:             log,
 		shutdownTimeout: time.Duration(metricCfg.ShutdownTimeoutSeconds) * time.Second,
@@ -74,10 +74,10 @@ func (s *Server) Serve(ctx context.Context) error {
 	}
 }
 
-func routes(mrec Recorder) http.Handler {
+func routes(pRec PromRecorder) http.Handler {
 	r := chi.NewRouter()
 
-	r.Get(groupMetrics, mrec.HTTPHandler().ServeHTTP)
+	r.Get(groupMetrics, pRec.HTTPHandler().ServeHTTP)
 
 	return r
 }

--- a/internal/servergrpc/chartapiserver_test.go
+++ b/internal/servergrpc/chartapiserver_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/limpidchart/lc-api/internal/backend"
 	"github.com/limpidchart/lc-api/internal/config"
+	"github.com/limpidchart/lc-api/internal/metric"
 	"github.com/limpidchart/lc-api/internal/render/github.com/limpidchart/lc-proto/render/v0"
 	"github.com/limpidchart/lc-api/internal/servergrpc"
 	"github.com/limpidchart/lc-api/internal/tcputils"
@@ -79,7 +80,7 @@ func newTestingChartAPIEnv(ctx context.Context, t *testing.T, opts testingChartA
 		t.Fatalf("unable to configure backend: %s", err)
 	}
 
-	chartAPIServer, err := servergrpc.NewServer(&log, b, cfg.GRPC, testutils.NewEmptyRecorder())
+	chartAPIServer, err := servergrpc.NewServer(&log, b, cfg.GRPC, metric.NewEmptyRecorder())
 	if err != nil {
 		t.Fatalf("unable to configure testing lc-api server: %s", err)
 	}

--- a/internal/servergrpc/interceptor/backend_check.go
+++ b/internal/servergrpc/interceptor/backend_check.go
@@ -12,9 +12,9 @@ import (
 )
 
 // BackendCheck checks if backend is healthy and returns codes.Unavailable status.Status if it's not.
-func BackendCheck(log *zerolog.Logger, b backend.Backend) grpc.UnaryServerInterceptor {
+func BackendCheck(log *zerolog.Logger, bCon backend.ConnSupervisor) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		if !b.IsHealthy() {
+		if !bCon.IsHealthy() {
 			log.Error().Msg("Backend connections are not healthy")
 
 			return nil, status.Errorf(codes.Unavailable, "Service Unavailable")

--- a/internal/servergrpchealthcheck/healthcheckserver_test.go
+++ b/internal/servergrpchealthcheck/healthcheckserver_test.go
@@ -11,10 +11,10 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/limpidchart/lc-api/internal/backend"
 	"github.com/limpidchart/lc-api/internal/config"
 	"github.com/limpidchart/lc-api/internal/servergrpchealthcheck"
 	"github.com/limpidchart/lc-api/internal/tcputils"
-	"github.com/limpidchart/lc-api/internal/testutils"
 )
 
 const testingHCEnvTimeoutSecs = 5
@@ -27,7 +27,7 @@ func newTestingHC(ctx context.Context, t *testing.T, healthy bool) *testingHCEnv
 	t.Helper()
 
 	log := zerolog.New(os.Stderr)
-	b := testutils.NewEmptyBackend(healthy)
+	b := backend.NewEmptyBackend(healthy)
 	hcCfg := config.GRPCHealthCheckConfig{
 		Address: tcputils.LocalhostWithRandomPort,
 	}

--- a/internal/serverhttp/v0/middleware/backend_check.go
+++ b/internal/serverhttp/v0/middleware/backend_check.go
@@ -10,10 +10,10 @@ import (
 )
 
 // BackendCheck checks if backend is healthy and returns http.StatusServiceUnavailable if it's not.
-func BackendCheck(log *zerolog.Logger, b backend.Backend) func(next http.Handler) http.Handler {
+func BackendCheck(log *zerolog.Logger, bCon backend.ConnSupervisor) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if !b.IsHealthy() {
+			if !bCon.IsHealthy() {
 				log.Error().Msg("Backend connections are not healthy")
 
 				MarshalJSON(w, http.StatusServiceUnavailable, view.NewError(http.StatusText(http.StatusServiceUnavailable)))

--- a/internal/serverhttp/v0/middleware/backend_check_test.go
+++ b/internal/serverhttp/v0/middleware/backend_check_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/limpidchart/lc-api/internal/backend"
 	"github.com/limpidchart/lc-api/internal/serverhttp/v0/middleware"
-	"github.com/limpidchart/lc-api/internal/testutils"
 )
 
 func TestBackendCheck_OK(t *testing.T) {
@@ -21,7 +21,7 @@ func TestBackendCheck_OK(t *testing.T) {
 
 	logger := zerolog.New(os.Stdout)
 	router := chi.NewRouter()
-	router.Use(middleware.BackendCheck(&logger, testutils.NewEmptyBackend(true)))
+	router.Use(middleware.BackendCheck(&logger, backend.NewEmptyBackend(true)))
 	router.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -47,7 +47,7 @@ func TestBackendCheck_Err(t *testing.T) {
 
 	logger := zerolog.New(os.Stdout)
 	router := chi.NewRouter()
-	router.Use(middleware.BackendCheck(&logger, testutils.NewEmptyBackend(false)))
+	router.Use(middleware.BackendCheck(&logger, backend.NewEmptyBackend(false)))
 	router.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/internal/serverhttp/v0/middleware/observer.go
+++ b/internal/serverhttp/v0/middleware/observer.go
@@ -37,7 +37,7 @@ const (
 )
 
 // RequestObserver handles observability (metrics and logging) for every request.
-func RequestObserver(log *zerolog.Logger, mrec metric.Recorder) func(next http.Handler) http.Handler {
+func RequestObserver(log *zerolog.Logger, pRec metric.PromRecorder) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ww := chimiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
@@ -51,7 +51,7 @@ func RequestObserver(log *zerolog.Logger, mrec metric.Recorder) func(next http.H
 				bytesWritten := ww.BytesWritten()
 				duration := time.Since(startTime)
 
-				mrec.RequestDuration().WithLabelValues(metric.ProtocolHTTP, r.Method, r.URL.Path, strconv.Itoa(statusCode)).Observe(duration.Seconds())
+				pRec.RequestDuration().WithLabelValues(metric.ProtocolHTTP, r.Method, r.URL.Path, strconv.Itoa(statusCode)).Observe(duration.Seconds())
 
 				switch {
 				case statusCode >= errCodesStart:

--- a/internal/serverhttp/v0/resource/chart/responses_test.go
+++ b/internal/serverhttp/v0/resource/chart/responses_test.go
@@ -20,7 +20,7 @@ func TestNewCreatedChartFromReply(t *testing.T) {
 	reqID := "red_id_1"
 	chartID := "chart_id_1"
 	data := []byte("svg_chart_data_1")
-	ts := time.Date(2021, 07, 22, 16, 58, 56, 0, time.UTC)
+	ts := time.Date(2021, 7, 22, 16, 58, 56, 0, time.UTC)
 
 	expected := &chart.Chart{
 		Body: struct {

--- a/internal/serverhttp/v0/resource/chart/routes_create_chart_test.go
+++ b/internal/serverhttp/v0/resource/chart/routes_create_chart_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/limpidchart/lc-api/internal/backend"
 	"github.com/limpidchart/lc-api/internal/config"
+	"github.com/limpidchart/lc-api/internal/metric"
 	"github.com/limpidchart/lc-api/internal/serverhttp"
 	"github.com/limpidchart/lc-api/internal/serverhttp/v0/resource/chart"
 	"github.com/limpidchart/lc-api/internal/serverhttp/v0/view"
@@ -131,7 +132,7 @@ func TestCreateChart_VerticalAndLineOK(t *testing.T) {
 	log := zerolog.New(os.Stderr)
 	router := chi.NewRouter()
 	router.Route(serverhttp.GroupV0, func(router chi.Router) {
-		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, b, testutils.NewEmptyRecorder()))
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, b, metric.NewEmptyRecorder()))
 	})
 
 	w := httptest.NewRecorder()
@@ -202,7 +203,7 @@ func TestCreateChart_VerticalAndLineOKGZIP(t *testing.T) {
 	log := zerolog.New(os.Stderr)
 	router := chi.NewRouter()
 	router.Route(serverhttp.GroupV0, func(router chi.Router) {
-		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, b, testutils.NewEmptyRecorder()))
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, b, metric.NewEmptyRecorder()))
 	})
 
 	w := httptest.NewRecorder()
@@ -279,7 +280,7 @@ func TestCreateChart_ErrTimeout(t *testing.T) {
 	log := zerolog.New(os.Stderr)
 	router := chi.NewRouter()
 	router.Route(serverhttp.GroupV0, func(router chi.Router) {
-		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, b, testutils.NewEmptyRecorder()))
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, b, metric.NewEmptyRecorder()))
 	})
 
 	w := httptest.NewRecorder()
@@ -332,7 +333,7 @@ func TestCreateChart_ErrNoAxes(t *testing.T) {
 	log := zerolog.New(os.Stderr)
 	router := chi.NewRouter()
 	router.Route(serverhttp.GroupV0, func(router chi.Router) {
-		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, b, testutils.NewEmptyRecorder()))
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, b, metric.NewEmptyRecorder()))
 	})
 
 	w := httptest.NewRecorder()
@@ -385,7 +386,7 @@ func TestCreateChart_ErrBadJSON(t *testing.T) {
 	log := zerolog.New(os.Stderr)
 	router := chi.NewRouter()
 	router.Route(serverhttp.GroupV0, func(router chi.Router) {
-		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, b, testutils.NewEmptyRecorder()))
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, b, metric.NewEmptyRecorder()))
 	})
 
 	w := httptest.NewRecorder()

--- a/internal/serverhttp/v0/resource/chart/routes_get_chart_test.go
+++ b/internal/serverhttp/v0/resource/chart/routes_get_chart_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/limpidchart/lc-api/internal/backend"
+	"github.com/limpidchart/lc-api/internal/metric"
 	"github.com/limpidchart/lc-api/internal/serverhttp"
 	"github.com/limpidchart/lc-api/internal/serverhttp/v0/resource/chart"
 	"github.com/limpidchart/lc-api/internal/testutils"
@@ -24,7 +26,7 @@ func TestGetChart_NotFound(t *testing.T) {
 	log := zerolog.New(os.Stderr)
 	router := chi.NewRouter()
 	router.Route(serverhttp.GroupV0, func(router chi.Router) {
-		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, testutils.NewEmptyBackend(true), testutils.NewEmptyRecorder()))
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, backend.NewEmptyBackend(true), metric.NewEmptyRecorder()))
 	})
 
 	w := httptest.NewRecorder()
@@ -58,7 +60,7 @@ func TestGetChart_BadChartID(t *testing.T) {
 	log := zerolog.New(os.Stderr)
 	router := chi.NewRouter()
 	router.Route(serverhttp.GroupV0, func(router chi.Router) {
-		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, testutils.NewEmptyBackend(true), testutils.NewEmptyRecorder()))
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, backend.NewEmptyBackend(true), metric.NewEmptyRecorder()))
 	})
 
 	w := httptest.NewRecorder()

--- a/internal/serverhttp/v0/resource/chart/routes_list_charts_test.go
+++ b/internal/serverhttp/v0/resource/chart/routes_list_charts_test.go
@@ -13,9 +13,10 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/limpidchart/lc-api/internal/backend"
+	"github.com/limpidchart/lc-api/internal/metric"
 	"github.com/limpidchart/lc-api/internal/serverhttp"
 	"github.com/limpidchart/lc-api/internal/serverhttp/v0/resource/chart"
-	"github.com/limpidchart/lc-api/internal/testutils"
 )
 
 func TestListCharts_Unimplemented(t *testing.T) {
@@ -24,7 +25,7 @@ func TestListCharts_Unimplemented(t *testing.T) {
 	log := zerolog.New(os.Stderr)
 	router := chi.NewRouter()
 	router.Route(serverhttp.GroupV0, func(router chi.Router) {
-		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, testutils.NewEmptyBackend(true), testutils.NewEmptyRecorder()))
+		router.Mount(serverhttp.GroupCharts, chart.Routes(&log, backend.NewEmptyBackend(true), metric.NewEmptyRecorder()))
 	})
 
 	w := httptest.NewRecorder()


### PR DESCRIPTION
Make interface implementation exported.

Move testing empty implementations from testutils package.