### PR TITLE
Shorten gRPC health check package name

### DIFF
--- a/cmd/lc-api/main.go
+++ b/cmd/lc-api/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/limpidchart/lc-api/internal/config"
 	"github.com/limpidchart/lc-api/internal/metric"
 	"github.com/limpidchart/lc-api/internal/servergrpc"
-	"github.com/limpidchart/lc-api/internal/servergrpchealthcheck"
+	"github.com/limpidchart/lc-api/internal/servergrpchc"
 	"github.com/limpidchart/lc-api/internal/serverhttp"
 )
 
@@ -115,7 +115,7 @@ func startHCServer(ctx context.Context, cancel context.CancelFunc, log *zerolog.
 		Str("address", hcCfg.Address).
 		Msg("Starting gRPC health check server")
 
-	hcServer, err := servergrpchealthcheck.NewServer(log, bCon, hcCfg)
+	hcServer, err := servergrpchc.NewServer(log, bCon, hcCfg)
 	if err != nil {
 		cancel()
 

--- a/internal/servergrpchc/healthcheckserver.go
+++ b/internal/servergrpchc/healthcheckserver.go
@@ -1,4 +1,4 @@
-package servergrpchealthcheck
+package servergrpchc
 
 import (
 	"context"

--- a/internal/servergrpchc/healthcheckserver_test.go
+++ b/internal/servergrpchc/healthcheckserver_test.go
@@ -1,4 +1,4 @@
-package servergrpchealthcheck_test
+package servergrpchc_test
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 
 	"github.com/limpidchart/lc-api/internal/backend"
 	"github.com/limpidchart/lc-api/internal/config"
-	"github.com/limpidchart/lc-api/internal/servergrpchealthcheck"
+	"github.com/limpidchart/lc-api/internal/servergrpchc"
 	"github.com/limpidchart/lc-api/internal/tcputils"
 )
 
@@ -32,7 +32,7 @@ func newTestingHC(ctx context.Context, t *testing.T, healthy bool) *testingHCEnv
 		Address: tcputils.LocalhostWithRandomPort,
 	}
 
-	hcServer, err := servergrpchealthcheck.NewServer(&log, b, hcCfg)
+	hcServer, err := servergrpchc.NewServer(&log, b, hcCfg)
 	if err != nil {
 		t.Fatalf("unable to configure testing lc-api gRPC health check server: %s", err)
 	}


### PR DESCRIPTION
Use "servergrpchc".